### PR TITLE
 Deprecated elements should have both the annotation and the Javadoc tag

### DIFF
--- a/mica-core/src/main/java/org/obiba/mica/dataset/domain/Dataset.java
+++ b/mica-core/src/main/java/org/obiba/mica/dataset/domain/Dataset.java
@@ -80,6 +80,10 @@ public abstract class Dataset extends AbstractGitPersistable implements Attribut
     this.entityType = entityType == null ? DEFAULT_ENTITY_TYPE : entityType;
   }
 
+  /**
+   * @deprecated kept for backward compatibility.
+   * @return
+     */
   @JsonIgnore
   @Deprecated
   public boolean isPublished() {

--- a/mica-core/src/main/java/org/obiba/mica/network/domain/Network.java
+++ b/mica-core/src/main/java/org/obiba/mica/network/domain/Network.java
@@ -95,12 +95,20 @@ public class Network extends AbstractGitPersistable implements AttributeAware, P
     this.acronym = acronym;
   }
 
+  /**
+   * @deprecated kept for backward compatibility.
+   * @return
+     */
   @Deprecated
   @JsonIgnore
   public boolean isPublished() {
     return published;
   }
 
+  /**
+   * @deprecated kept for backward compatibility.
+   * @param published
+     */
   @Deprecated
   @JsonProperty
   public void setPublished(boolean published) {

--- a/mica-core/src/main/java/org/obiba/mica/study/domain/DataCollectionEvent.java
+++ b/mica-core/src/main/java/org/obiba/mica/study/domain/DataCollectionEvent.java
@@ -172,12 +172,20 @@ public class DataCollectionEvent extends AbstractAttributeAware
     this.otherBioSamples = otherBioSamples;
   }
 
+  /**
+   * @deprecated kept for backward compatibility.
+   * @return
+     */
   @Deprecated
   @JsonIgnore
   public List<Attachment> getAttachments() {
     return attachments;
   }
 
+  /**
+   * @deprecated kept for backward compatibility.
+   * @param attachments
+     */
   @Deprecated
   @JsonProperty
   public void setAttachments(@NotNull List<Attachment> attachments) {

--- a/mica-core/src/main/java/org/obiba/mica/study/domain/Study.java
+++ b/mica-core/src/main/java/org/obiba/mica/study/domain/Study.java
@@ -302,12 +302,20 @@ public class Study extends AbstractGitPersistable implements AttributeAware, Per
     this.pubmedId = pubmedId;
   }
 
+  /**
+   * @deprecated kept for backward compatibility.
+   * @return
+     */
   @Deprecated
   @JsonIgnore
   public List<Attachment> getAttachments() {
     return attachments;
   }
 
+  /**
+   * @deprecated kept for backward compatibility.
+   * @param attachments
+     */
   @Deprecated
   @JsonProperty
   public void setAttachments(List<Attachment> attachments) {

--- a/mica-rest/src/main/java/org/obiba/mica/micaConfig/rest/MicaConfigResource.java
+++ b/mica-rest/src/main/java/org/obiba/mica/micaConfig/rest/MicaConfigResource.java
@@ -225,6 +225,10 @@ public class MicaConfigResource {
       .collect(Collectors.toMap(lang -> lang, lang -> new Locale(lang).getDisplayLanguage(locale)));
   }
 
+  /**
+   * @deprecated kept for backward compatibility.
+   * @return
+     */
   @GET
   @Path("/taxonomies")
   @RequiresAuthentication
@@ -233,6 +237,10 @@ public class MicaConfigResource {
     return opalService.getTaxonomyDtos();
   }
 
+  /**
+   * @deprecated kept for backward compatibility.
+   * @return
+     */
   @GET
   @Path("/taxonomies/summaries")
   @RequiresAuthentication
@@ -241,6 +249,10 @@ public class MicaConfigResource {
     return opalService.getTaxonomySummaryDtos();
   }
 
+  /**
+   * @deprecated kept for backward compatibility.
+   * @return
+     */
   @GET
   @Path("/taxonomies/vocabularies/summaries")
   @RequiresAuthentication
@@ -249,6 +261,10 @@ public class MicaConfigResource {
     return opalService.getTaxonomyVocabularySummaryDtos();
   }
 
+  /**
+   * @deprecated kept for backward compatibility.
+   * @return
+     */
   @GET
   @Path("/studies")
   @RequiresAuthentication


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:MissingDeprecatedCheck - “ Deprecated elements should have both the annotation and the Javadoc tag ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:MissingDeprecatedCheck
Please let me know if you have any questions.
Ayman Abdelghany.