### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/mica-core/src/main/java/org/obiba/mica/PdfUtils.java
+++ b/mica-core/src/main/java/org/obiba/mica/PdfUtils.java
@@ -16,6 +16,9 @@ import com.itextpdf.text.pdf.PdfStamper;
 
 public class PdfUtils {
 
+  private PdfUtils() {
+  }
+
   public static void addImage(byte[] input, OutputStream output, Image image, String placeholder)
     throws IOException, DocumentException {
     try (PdfReaderAutoclosable pdfReader = new PdfReaderAutoclosable(input);

--- a/mica-core/src/main/java/org/obiba/mica/security/SubjectUtils.java
+++ b/mica-core/src/main/java/org/obiba/mica/security/SubjectUtils.java
@@ -7,6 +7,9 @@ import org.apache.shiro.subject.Subject;
 import org.obiba.shiro.authc.SudoAuthToken;
 
 public class SubjectUtils {
+  private SubjectUtils() {
+  }
+
   public static <V> V sudo(Callable<V> callable) {
     Subject sudo = new Subject.Builder().principals(
       SecurityUtils.getSecurityManager().authenticate(new SudoAuthToken(SecurityUtils.getSubject())).getPrincipals())

--- a/mica-rest/src/test/java/org/obiba/mica/web/rest/TestUtil.java
+++ b/mica-rest/src/test/java/org/obiba/mica/web/rest/TestUtil.java
@@ -20,6 +20,9 @@ public class TestUtil {
   public static final MediaType APPLICATION_JSON_UTF8 = new MediaType(MediaType.APPLICATION_JSON.getType(),
       MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
 
+  private TestUtil() {
+  }
+
   /**
    * Convert an object to JSON byte array.
    *

--- a/mica-search/src/main/java/org/obiba/mica/dataset/search/rest/harmonized/ContingencyUtils.java
+++ b/mica-search/src/main/java/org/obiba/mica/dataset/search/rest/harmonized/ContingencyUtils.java
@@ -17,6 +17,9 @@ import static java.util.stream.Collectors.toSet;
 
 public class ContingencyUtils {
 
+  private ContingencyUtils() {
+  }
+
   public static List<String> getTermsHeaders(DatasetVariable variable, Mica.DatasetVariableContingenciesDto dto) {
     List<String> dtoTerms = Lists.newArrayList(
       dto.getContingenciesList().stream().flatMap(c -> c.getAggregationsList().stream()).map(a -> a.getTerm())


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.