### PR TITLE
MK-886 - Integrate word count validation in schema form

### DIFF
--- a/mica-webapp/src/main/webapp/app/app.js
+++ b/mica-webapp/src/main/webapp/app/app.js
@@ -259,4 +259,26 @@ mica
       AuthenticationSharedService.initSession().finally(function() {
         isSessionInitialized = true;
       });
+    }])
+
+  .config(['schemaFormProvider',
+    function (schemaFormProvider) {
+      schemaFormProvider.postProcess(function (form) {
+        form.filter(function (e) {
+          return e.hasOwnProperty('wordLimit');
+        }).forEach(function (e) {
+          e.$validators = {
+            wordLimitError: function (value) {
+              if (angular.isDefined(value) && value !== null) {
+                var wordCount = (value.match(/\S+/g) || []).length;
+                if (wordCount > parseInt(e.wordLimit)) {
+                  return false;
+                }
+              }
+              return true;
+            }
+          };
+        });
+        return form;
+      })
     }]);


### PR DESCRIPTION
added post processor that will add the wordLimit validator when the key word 'wordLimit' is present in the schemaForm definition, user will have to add the 'wordLimitError' validationMessage in the definition