### PR TITLE
MK-1043 - cycle warning for 'NumberOfParticipants' mitigated

### DIFF
--- a/mica-core/src/main/java/org/obiba/mica/study/domain/Population.java
+++ b/mica-core/src/main/java/org/obiba/mica/study/domain/Population.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Sets;
 import org.obiba.mica.core.domain.AbstractAttributeModelAware;
 import org.obiba.mica.core.domain.AttributeAware;
 import org.obiba.mica.core.domain.LocalizedString;
+import org.springframework.data.mongodb.core.mapping.Field;
 
 public class Population extends AbstractAttributeModelAware implements Serializable, Comparable<Population>, AttributeAware {
 
@@ -45,6 +46,7 @@ public class Population extends AbstractAttributeModelAware implements Serializa
 
   private SelectionCriteria selectionCriteria;
 
+  @Field("PopulationNumberOfParticipant")
   private NumberOfParticipants numberOfParticipants;
 
   private LocalizedString info;


### PR DESCRIPTION
The '@Field' would only change the name of the field in the mongo bson as per http://docs.spring.io/spring-data/mongodb/docs/1.8.4.RELEASE/reference/html/#mapping-usage-annotations.