### PR TITLE
use ngStrictDi to check for explicit dependency injection annotations

### DIFF
--- a/mica-webapp/src/main/webapp/index.html
+++ b/mica-webapp/src/main/webapp/index.html
@@ -45,7 +45,7 @@
   <!-- endbuild -->
   <link rel="stylesheet" href="ws/config/style.css">
 </head>
-<body ng-app="mica" ng-controller="MainController" ng-cloak>
+<body ng-app="mica" ng-strict-di="true" ng-controller="MainController" ng-cloak>
 <!--[if lt IE 10]>
 <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade
   your browser</a> to improve your experience.</p>


### PR DESCRIPTION
This would make the application fail if we don't use the di annotations (the square bracket with the name of the components to inject).