### PR TITLE
MK-1181 - do a targeted re-index when saving a taxonomy config

### DIFF
--- a/mica-core/src/main/java/org/obiba/mica/micaConfig/event/TaxonomiesUpdatedEvent.java
+++ b/mica-core/src/main/java/org/obiba/mica/micaConfig/event/TaxonomiesUpdatedEvent.java
@@ -11,7 +11,26 @@
 
 package org.obiba.mica.micaConfig.event;
 
+import org.obiba.mica.core.domain.TaxonomyTarget;
+
 public class TaxonomiesUpdatedEvent {
 
   public TaxonomiesUpdatedEvent() {}
+
+  public TaxonomiesUpdatedEvent(String taxonomyName, TaxonomyTarget taxonomyTarget) {
+    this.taxonomyName = taxonomyName;
+    this.taxonomyTarget = taxonomyTarget;
+  }
+
+  private String taxonomyName;
+
+  private TaxonomyTarget taxonomyTarget;
+
+  public String getTaxonomyName() {
+    return taxonomyName;
+  }
+
+  public TaxonomyTarget getTaxonomyTarget() {
+    return taxonomyTarget;
+  }
 }

--- a/mica-core/src/main/java/org/obiba/mica/micaConfig/service/TaxonomyConfigService.java
+++ b/mica-core/src/main/java/org/obiba/mica/micaConfig/service/TaxonomyConfigService.java
@@ -65,7 +65,7 @@ public class TaxonomyConfigService {
   public void update(TaxonomyTarget target, Taxonomy taxonomy) {
     updateInternal(target, taxonomy);
     getEvent(target).ifPresent(eventBus::post);
-    eventBus.post(new TaxonomiesUpdatedEvent());
+    eventBus.post(new TaxonomiesUpdatedEvent(taxonomy.getName(), target));
   }
 
   private Taxonomy findByTargetInternal(TaxonomyTarget target) {

--- a/mica-webapp/src/main/webapp/app/entity-config/entity-config-controller.js
+++ b/mica-webapp/src/main/webapp/app/entity-config/entity-config-controller.js
@@ -26,6 +26,7 @@ mica.entityConfig
     'MicaConfigResource',
     'EntityFormAccessesResource',
     'AlertBuilder',
+    '$cacheFactory',
     function ($scope,
               $q,
               $location,
@@ -36,7 +37,8 @@ mica.entityConfig
               EntityFormPermissionsResource,
               MicaConfigResource,
               EntityFormAccessesResource,
-              AlertBuilder) {
+              AlertBuilder,
+              $cacheFactory) {
       var FORMS = {'network': ['network'],
         'study': ['study', 'population', 'data-collection-event'],
         'study-dataset': ['study-dataset'],
@@ -168,6 +170,10 @@ mica.entityConfig
           $q.all(res).then(function (res) {
             AlertBuilder.newBuilder().type('info').trMsg('entity-config.save-alert.success').build();
             $scope.state.setDirty(false);
+            var taxonomyResourceCache = $cacheFactory.get('taxonomyResource');
+            if (taxonomyResourceCache) {
+              taxonomyResourceCache.removeAll();
+            }
             return res;
           }).catch(function (res) {
             AlertBuilder.newBuilder().trMsg(res).build();


### PR DESCRIPTION
On the server side, when updating a taxonomy config (STUDY, NETWORK, DATASET [ and VARIABLE]), the taxonomy update event that is triggered will delete and index the taxonomies for the targeted taxonomy only.

The client will clear the angular session cache. 

This would affect the search page such that after an entity config update the taxonomy resource cache would be cleared thus an updated list of vocabularies would be shown for the search panel.

This will only affect mica2, not mica-drupal. For mica-drupal, unfortunatly, a page refresh would be required. 