### PR TITLE
MK-1181 - use bulkRequest for delete

### DIFF
--- a/mica-core/src/main/java/org/obiba/mica/micaConfig/service/TaxonomyConfigService.java
+++ b/mica-core/src/main/java/org/obiba/mica/micaConfig/service/TaxonomyConfigService.java
@@ -10,8 +10,6 @@
 
 package org.obiba.mica.micaConfig.service;
 
-import java.util.Optional;
-
 import javax.inject.Inject;
 
 import org.obiba.mica.NoSuchEntityException;
@@ -22,11 +20,8 @@ import org.obiba.mica.config.taxonomies.TaxonomyTaxonomy;
 import org.obiba.mica.config.taxonomies.VariableTaxonomy;
 import org.obiba.mica.core.domain.TaxonomyEntityWrapper;
 import org.obiba.mica.core.domain.TaxonomyTarget;
-import org.obiba.mica.dataset.event.IndexDatasetsEvent;
 import org.obiba.mica.micaConfig.event.TaxonomiesUpdatedEvent;
 import org.obiba.mica.micaConfig.repository.TaxonomyConfigRepository;
-import org.obiba.mica.network.event.IndexNetworksEvent;
-import org.obiba.mica.study.event.IndexStudiesEvent;
 import org.obiba.opal.core.domain.taxonomy.Taxonomy;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Service;
@@ -64,7 +59,6 @@ public class TaxonomyConfigService {
 
   public void update(TaxonomyTarget target, Taxonomy taxonomy) {
     updateInternal(target, taxonomy);
-    getEvent(target).ifPresent(eventBus::post);
     eventBus.post(new TaxonomiesUpdatedEvent(taxonomy.getName(), target));
   }
 
@@ -85,24 +79,6 @@ public class TaxonomyConfigService {
     taxonomyEntityWrapper.setTarget(target.asId());
     taxonomyEntityWrapper.setTaxonomy(taxonomy);
     taxonomyConfigRepository.save(taxonomyEntityWrapper);
-  }
-
-  private Optional<Object> getEvent(TaxonomyTarget target) {
-    Object event = null;
-
-    switch (target) {
-      case STUDY:
-        event = new IndexStudiesEvent();
-        break;
-      case NETWORK:
-        event = new IndexNetworksEvent();
-        break;
-      case DATASET:
-        event = new IndexDatasetsEvent();
-        break;
-    }
-
-    return Optional.ofNullable(event);
   }
 
   private void createDefault(TaxonomyTarget target) {

--- a/mica-search/src/main/java/org/obiba/mica/taxonomy/TaxonomyIndexer.java
+++ b/mica-search/src/main/java/org/obiba/mica/taxonomy/TaxonomyIndexer.java
@@ -70,10 +70,7 @@ public class TaxonomyIndexer {
       index(TaxonomyTarget.NETWORK, Lists.newArrayList(taxonomyService.getNetworkTaxonomy()));
     } else {
       QueryBuilder query = QueryBuilders.boolQuery().must(QueryBuilders.wildcardQuery("id", event.getTaxonomyName() + '*'));
-
-      elasticSearchIndexer.delete(TAXONOMY_INDEX, TAXONOMY_TYPE, query);
-      elasticSearchIndexer.delete(TAXONOMY_INDEX, TAXONOMY_VOCABULARY_TYPE, query);
-      elasticSearchIndexer.delete(TAXONOMY_INDEX, TAXONOMY_TERM_TYPE, query);
+      elasticSearchIndexer.delete(TAXONOMY_INDEX, new String[] {TAXONOMY_TYPE, TAXONOMY_VOCABULARY_TYPE, TAXONOMY_TERM_TYPE}, query);
 
       switch (event.getTaxonomyTarget()) {
         case STUDY:


### PR DESCRIPTION
Removed events for indexing documents when taxonomy is updated. Indexing the documents would not be necessary at that stage because none of the documents would be using a newly created taxonomy or even if deleted (or renamed/moved), the taxonomy would not be found in the search.

Instead of calling delete index multiple times for each types (doing multiple searches), do the search once and do the delete request per type. The delete request is then added in a bulk request such that elastic search would be the one to manage those instead of mica.