### PR TITLE
MK-1199 - no timeline when multiple dce on page refresh

### DIFF
--- a/mica-webapp/src/main/webapp/app/study/study-controller.js
+++ b/mica-webapp/src/main/webapp/app/study/study-controller.js
@@ -213,7 +213,9 @@ mica.study
           $scope.timeline = new $.MicaTimeline(new $.StudyDtoParser());
         }
 
-        $scope.timeline.reset().create('#timeline', study).addLegend();
+        $timeout(function () {
+          $scope.timeline.reset().create('#timeline', study).addLegend();
+        });
       };
 
       var initializeStudy = function (study) {


### PR DESCRIPTION
Wrap timeline creation in a $timeout in order to simulate a DOM.ready event on angularjs' side.
Error was due to '#timeline' not existing when page was rendered.