### PR TITLE
Mongo setting is uri-based for compatibility with driver 3.x

### DIFF
--- a/mica-webapp/src/main/conf/application-dev.yml
+++ b/mica-webapp/src/main/conf/application-dev.yml
@@ -37,9 +37,7 @@ spring:
   profiles: dev
   data:
     mongodb:
-      host: localhost
-      port: 27017
-      database: mica
+      uri: mongodb://localhost:27017/mica
   thymeleaf:
     mode: XHTML
     cache: false

--- a/mica-webapp/src/main/conf/application.yml
+++ b/mica-webapp/src/main/conf/application.yml
@@ -45,9 +45,7 @@ shiro:
 spring:
   data:
     mongodb:
-      host: localhost
-      port: 27017
-      database: mica
+      uri: mongodb://localhost:27017/mica
   profiles: prod
   thymeleaf:
     mode: XHTML


### PR DESCRIPTION
See [spring boot mongo documentation](http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-nosql.html#boot-features-connecting-to-mongodb).