### PR TITLE
MK-1213 - only show confgured languages in the language switcher

### DIFF
--- a/mica-webapp/src/main/webapp/app/controllers.js
+++ b/mica-webapp/src/main/webapp/app/controllers.js
@@ -57,13 +57,17 @@ mica.controller('MainController', [
 
 mica.controller('AdminController', [function () {}]);
 
-mica.controller('LanguageController', ['$scope', '$translate', 'amMoment',
-  function ($scope, $translate, amMoment) {
+mica.controller('LanguageController', ['$scope', '$translate', 'amMoment', 'MicaConfigResource',
+  function ($scope, $translate, amMoment, MicaConfigResource) {
     $scope.changeLanguage = function (languageKey) {
       $translate.use(languageKey);
       amMoment.changeLocale(languageKey);
     };
     $scope.getCurrentLanguage = $translate.use;
+
+    MicaConfigResource.get(function (config) {
+      $scope.languages = config.languages;
+    });
   }]);
 
 mica.controller('MenuController', [function () {}]);

--- a/mica-webapp/src/main/webapp/index.html
+++ b/mica-webapp/src/main/webapp/index.html
@@ -120,8 +120,7 @@
             <i class="fa fa-caret-down"></i></a>
           <ul class="dropdown-menu pull-right" ng-controller="LanguageController">
             <!--<li><a href="#/profile"><i class="fa fa-cog"></i> <span translate>global.menu.myProfile</span></a></li>-->
-            <!-- TODO ask server for langs instead-->
-            <li ng-repeat="lang in ['en','fr']">
+            <li ng-repeat="lang in languages">
               <a href ng-click="changeLanguage(lang)">
                 <span>{{'language.' + lang | translate}}</span> <i class="fa fa-check" aria-hidden="true" ng-show="getCurrentLanguage() === lang"></i></a>
             </li>


### PR DESCRIPTION
This would ensure that translations would be configured for searches in a particular language.