### PR TITLE
MK-1252 - add validator to role creation in config and translate role key in member buttons

### DIFF
--- a/mica-webapp/src/main/resources/i18n/en.json
+++ b/mica-webapp/src/main/resources/i18n/en.json
@@ -319,6 +319,7 @@
     "delete-role-confirm": "This operation will remove members with this role from all documents, i.e. studies, networks. Are you sure you want to delete role \"{{role}}\"?",
     "role-help": "Role unique identifier.",
     "role-error": "Role identifier already exists.",
+    "role-character-error": "Role identifier contains invalid characters. Please avoid characters such as uppercase, spaces, '~' and '!'.",
     "notifications": {
       "title": "Notifications",
       "info": "Notification emails can be sent to relevant users and groups.",

--- a/mica-webapp/src/main/resources/i18n/fr.json
+++ b/mica-webapp/src/main/resources/i18n/fr.json
@@ -318,6 +318,7 @@
     "delete-role-confirm": "Cette opération va supprimer les membres avec ce rôle de tous les documents, à savoir les études et les réseaux. Etes-vous sûr de vouloir supprimer le rôle \"{{role}}\"?",
     "role-help": "Identifiant unique du rôle.",
     "role-error": "L'identifiant du rôle existe déjà.",
+    "role-character-error": "L'identifiant du rôle contient des charactères spéciaux. Veuillez éviter les caractères tel que les majuscules, espaces, '~' et '!'.",
     "notifications": {
       "title": "Notifications",
       "info": "Des courriels de notification peuvent être envoyés aux utilisateurs et aux groupes concernés.",

--- a/mica-webapp/src/main/webapp/app/config/config-controller.js
+++ b/mica-webapp/src/main/webapp/app/config/config-controller.js
@@ -307,10 +307,19 @@ mica.config
   .controller('RoleModalController', ['$scope', '$uibModalInstance', '$log', 'micaConfig', 'role',
     function ($scope, $uibModalInstance, $log, micaConfig, role) {
       var oldRole = role;
+      var hasSpecialCharacters = function (str) {
+        if (str && typeof str === 'string') {
+          var result = str.match(/[A-Z\s~!]/g);
+          return result;
+        }
+
+        return false;
+      };
       $scope.role = {id: role};
 
       $scope.save = function (form) {
         form.id.$setValidity('text', !micaConfig.roles || micaConfig.roles.indexOf($scope.role.id) < 0 || $scope.role.id === oldRole);
+        form.id.$setValidity('character', !hasSpecialCharacters($scope.role.id));
 
         if (form.$valid) {
           $uibModalInstance.close($scope.role.id);

--- a/mica-webapp/src/main/webapp/app/config/views/config-roles-modal-form.html
+++ b/mica-webapp/src/main/webapp/app/config/views/config-roles-modal-form.html
@@ -21,6 +21,8 @@
     <div class="modal-body">
       <p class="alert alert-danger" ng-show="form.saveAttempted && form.id.$error.text" translate>
         config.role-error</p>
+      <p class="alert alert-danger" ng-show="form.saveAttempted && form.id.$error.character" translate>
+        config.role-character-error</p>
       <div form-input name="id" model="role.id" label="id" help="config.role-help" required="true"></div>
     </div>
 

--- a/mica-webapp/src/main/webapp/app/network/views/network-view-details.html
+++ b/mica-webapp/src/main/webapp/app/network/views/network-view-details.html
@@ -152,7 +152,7 @@
               <table class="table table-bordered table-striped">
                 <tbody>
                 <tr ng-repeat="role in roles">
-                  <th>{{'network.member-list' | translate: {type: role} }}</th>
+                  <th translate="network.member-list" translate-values="{{ {type: (role | translate)} }}"></th>
                   <td>
                     <div ng-controller="ContactController">
                       <ul ui-sortable="sortableOptions" ng-model="memberships[role]" class="list-unstyled sortable" ng-show="memberships[role].length">
@@ -168,7 +168,7 @@
                         </li>
                       </ul>
                       <button type="button" class="btn btn-responsive btn-info btn-sm hidden-print" ng-click="addMember(network, role)" ng-if="inViewMode() && permissions.canEdit()">
-                        <i class="fa fa-plus"></i> <span>{{ 'network.add-member' | translate: {type: role} }}</span>
+                        <i class="fa fa-plus"></i> <span translate="network.add-member" translate-values="{{ {type: (role | translate)} }}"></span>
                       </button>
                     </div>
                   </td>

--- a/mica-webapp/src/main/webapp/app/study/views/study-view-details.html
+++ b/mica-webapp/src/main/webapp/app/study/views/study-view-details.html
@@ -24,7 +24,7 @@
           <table class="table table-bordered table-striped">
           <tbody>
           <tr ng-repeat="role in roles">
-            <th>{{'study.member-list' | translate: {type: role} }}</th>
+            <th translate="study.member-list" translate-values="{{ {type: (role | translate)} }}"></th>
             <td>
               <div ng-controller="ContactController">
                 <ul ui-sortable="sortableOptions" ng-model="memberships[role]" class="list-unstyled sortable" ng-show="memberships[role].length">
@@ -43,7 +43,7 @@
                   </li>
                 </ul>
                 <button type="button" class="btn btn-info btn-responsive btn-sm hidden-print" ng-click="addMember(study, role)" ng-if="inViewMode() && permissions.canEdit()">
-                  <i class="fa fa-plus"></i> <span>{{ 'study.add-member' | translate: {type: role} }}</span>
+                  <i class="fa fa-plus"></i> <span translate="study.add-member" translate-values="{{ {type: (role | translate)} }}"></span>
                 </button>
               </div>
             </td>


### PR DESCRIPTION
Current keys with spaces and upper cases will still work. One only has to create the translation key exactly as the id was created.

