### PR TITLE
MK-1251 - translate the default role ids

### DIFF
--- a/mica-webapp/src/main/resources/i18n/en.json
+++ b/mica-webapp/src/main/resources/i18n/en.json
@@ -313,7 +313,7 @@
     "harmonization-dataset-enabled": "Harmonization datasets section enabled",
     "harmonization-dataset-enabled-help": "Harmonization datasets section is accessible.",
     "roles": "Membership Roles",
-    "roles-help": "A person can be member of a study or of a network with one of the listed roles.",
+    "roles-help": "A person can be member of a study or of a network with one of the listed roles. * Use the prefix <a href='#/admin/translations/edit?filter=membership-role.'>'membership-role.'</a> to change the translation.",
     "add-role": "Add Role",
     "delete-role-title": "Delete Role",
     "delete-role-confirm": "This operation will remove members with this role from all documents, i.e. studies, networks. Are you sure you want to delete role \"{{role}}\"?",
@@ -1533,5 +1533,9 @@
         "status-detail": "Status Detail"
       }
     }
+  },
+  "membership-role": {
+    "investigator": "investigator",
+    "contact": "contact"
   }
 }

--- a/mica-webapp/src/main/resources/i18n/fr.json
+++ b/mica-webapp/src/main/resources/i18n/fr.json
@@ -312,7 +312,7 @@
     "harmonization-dataset-enabled": "Section ensemble de données d'harmonisation activée",
     "harmonization-dataset-enabled-help": "Des ensembles de données d'harmonisation sont présents dans Mica.",
     "roles": "Rôles des personnes membres",
-    "roles-help": "Une personne peut être membre d'une étude ou d'un réseau avec l'un des rôles énumérés.",
+    "roles-help": "Une personne peut être membre d'une étude ou d'un réseau avec l'un des rôles énumérés. * Utiliser le préfixe <a href='#/admin/translations/edit?filter=membership-role.'>'membership-role.'</a> pour changer la traduction.",
     "add-role": "Ajouter un rôle",
     "delete-role-title": "Supprimer le rôle",
     "delete-role-confirm": "Cette opération va supprimer les membres avec ce rôle de tous les documents, à savoir les études et les réseaux. Etes-vous sûr de vouloir supprimer le rôle \"{{role}}\"?",
@@ -1535,5 +1535,9 @@
         "status-detail": "Détail du statut"
       }
     }
+  },
+  "membership-role": {
+    "investigator": "enquêteur",
+    "contact": "contact"
   }
 }

--- a/mica-webapp/src/main/webapp/app/config/config-controller.js
+++ b/mica-webapp/src/main/webapp/app/config/config-controller.js
@@ -474,8 +474,10 @@ mica.config
 
     }])
   .controller('MicaConfigTranslationsEditController', ['$scope', '$q', '$resource', '$window', '$location', '$log', '$uibModal',
-    'MicaConfigResource', 'FormServerValidation', 'TranslationsResource',
-    function ($scope, $q, $resource, $window, $location, $log, $uibModal, MicaConfigResource, FormServerValidation, TranslationsResource) {
+    'MicaConfigResource', 'FormServerValidation', 'TranslationsResource', '$route',
+    function ($scope, $q, $resource, $window, $location, $log, $uibModal, MicaConfigResource, FormServerValidation, TranslationsResource, $route) {
+      $scope.filter = $route.current.params.filter;
+
       var updates = {}, oldTranslations = {};
       $scope.micaConfig = MicaConfigResource.get();
       $scope.micaConfig.$promise.then(function() {

--- a/mica-webapp/src/main/webapp/app/network/views/network-view-details.html
+++ b/mica-webapp/src/main/webapp/app/network/views/network-view-details.html
@@ -152,7 +152,7 @@
               <table class="table table-bordered table-striped">
                 <tbody>
                 <tr ng-repeat="role in roles">
-                  <th translate="network.member-list" translate-values="{{ {type: (role | translate)} }}"></th>
+                  <th translate="network.member-list" translate-values="{{ {type: ('membership-role.' + role | translate)} }}"></th>
                   <td>
                     <div ng-controller="ContactController">
                       <ul ui-sortable="sortableOptions" ng-model="memberships[role]" class="list-unstyled sortable" ng-show="memberships[role].length">
@@ -168,7 +168,7 @@
                         </li>
                       </ul>
                       <button type="button" class="btn btn-responsive btn-info btn-sm hidden-print" ng-click="addMember(network, role)" ng-if="inViewMode() && permissions.canEdit()">
-                        <i class="fa fa-plus"></i> <span translate="network.add-member" translate-values="{{ {type: (role | translate)} }}"></span>
+                        <i class="fa fa-plus"></i> <span translate="network.add-member" translate-values="{{ {type: ('membership-role.' + role | translate)} }}"></span>
                       </button>
                     </div>
                   </td>

--- a/mica-webapp/src/main/webapp/app/study/views/study-view-details.html
+++ b/mica-webapp/src/main/webapp/app/study/views/study-view-details.html
@@ -24,7 +24,7 @@
           <table class="table table-bordered table-striped">
           <tbody>
           <tr ng-repeat="role in roles">
-            <th translate="study.member-list" translate-values="{{ {type: (role | translate)} }}"></th>
+            <th translate="study.member-list" translate-values="{{ {type: ('membership-role.' + role | translate)} }}"></th>
             <td>
               <div ng-controller="ContactController">
                 <ul ui-sortable="sortableOptions" ng-model="memberships[role]" class="list-unstyled sortable" ng-show="memberships[role].length">
@@ -43,7 +43,7 @@
                   </li>
                 </ul>
                 <button type="button" class="btn btn-info btn-responsive btn-sm hidden-print" ng-click="addMember(study, role)" ng-if="inViewMode() && permissions.canEdit()">
-                  <i class="fa fa-plus"></i> <span translate="study.add-member" translate-values="{{ {type: (role | translate)} }}"></span>
+                  <i class="fa fa-plus"></i> <span translate="study.add-member" translate-values="{{ {type: ('membership-role.' + role | translate)} }}"></span>
                 </button>
               </div>
             </td>


### PR DESCRIPTION
Also modified the help text to inform of the prefix to add in the translation as well as a link to the translation page.

It should also be noted that old ids with spaces and upper cases will still work.