### PR TITLE
use proxyMode TARGET_CLASS

### DIFF
--- a/mica-search/src/main/java/org/obiba/mica/file/search/EsPublishedFileService.java
+++ b/mica-search/src/main/java/org/obiba/mica/file/search/EsPublishedFileService.java
@@ -35,7 +35,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 
 @Component
-@Scope(scopeName = "request", proxyMode = ScopedProxyMode.INTERFACES)
+@Scope(scopeName = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
 public class EsPublishedFileService extends AbstractDocumentService<AttachmentState> implements PublishedFileService {
   private static final Logger log = LoggerFactory.getLogger(AbstractDocumentQuery.class);
 


### PR DESCRIPTION
ScopedProxyMode.INTERFACES uses jdk proxies targetting the beans interface types only while ScopedProxyMode.TARGET_CLASS would use CGLIB proxies targeting class AND interface types.