### PR TITLE
MK-1162 - add datasetId and index sorts for a variable search query

### DIFF
--- a/mica-search/src/main/java/org/obiba/mica/search/queries/AbstractDocumentQuery.java
+++ b/mica-search/src/main/java/org/obiba/mica/search/queries/AbstractDocumentQuery.java
@@ -39,6 +39,8 @@ import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.sort.SortBuilder;
+import org.elasticsearch.search.sort.SortBuilders;
+import org.elasticsearch.search.sort.SortOrder;
 import org.obiba.mica.micaConfig.service.MicaConfigService;
 import org.obiba.mica.micaConfig.service.TaxonomyService;
 import org.obiba.mica.micaConfig.service.helper.AggregationMetaDataProvider;
@@ -369,6 +371,12 @@ public abstract class AbstractDocumentQuery {
       .addAggregation(AggregationBuilders.global(AGG_TOTAL_COUNT)); // ;
 
     if(ignoreFields()) requestBuilder.setNoFields();
+
+    // apply default sort for VariableQuery before any user defined ones (order is important)
+    if (this instanceof VariableQuery) {
+      requestBuilder.addSort(SortBuilders.fieldSort("datasetId").order(SortOrder.ASC));
+      requestBuilder.addSort(SortBuilders.fieldSort("index").order(SortOrder.ASC));
+    }
 
     if(sortBuilder != null) requestBuilder.addSort(sortBuilder);
 


### PR DESCRIPTION
The variable query result would thus be sorted by datasetId then index and finally by the client defined sort (in our case it is by name). It would however be best if index was not set to "0" for all variables.  