### PR TITLE
MK-1323 - set iniRealm first in the realm list such that it is the fir…

### DIFF
--- a/mica-core/src/main/java/org/obiba/mica/security/SecurityManagerFactory.java
+++ b/mica-core/src/main/java/org/obiba/mica/security/SecurityManagerFactory.java
@@ -20,6 +20,7 @@ import net.sf.ehcache.CacheManager;
 
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.authc.credential.PasswordMatcher;
+import org.apache.shiro.authc.pam.AtLeastOneSuccessfulStrategy;
 import org.apache.shiro.authc.pam.FirstSuccessfulStrategy;
 import org.apache.shiro.authc.pam.ModularRealmAuthenticator;
 import org.apache.shiro.authz.ModularRealmAuthorizer;
@@ -192,7 +193,7 @@ public class SecurityManagerFactory implements FactoryBean<SessionsSecurityManag
     @Override
     protected void applyRealmsToSecurityManager(Collection<Realm> shiroRealms, @SuppressWarnings(
         "ParameterHidesMemberVariable") SecurityManager securityManager) {
-      ImmutableList.Builder<Realm> builder = ImmutableList.<Realm>builder().addAll(realms).addAll(shiroRealms);
+      ImmutableList.Builder<Realm> builder = ImmutableList.<Realm>builder().addAll(shiroRealms).addAll(realms);
       RelaxedPropertyResolver propertyResolver = new RelaxedPropertyResolver(env, "agate.");
       String obibaRealmUrl = propertyResolver.getProperty("url");
       String serviceName = propertyResolver.getProperty("application.name");


### PR DESCRIPTION
…st realm that is checked as per https://shiro.apache.org/authentication.html#Authentication-RealmAuthenticationOrder.

Next would be to implement this JIRA's solution https://github.com/bdemers/shiro/commit/b8a631877fee239413b45dbfc118de2759ab9c75 where a "continueAfterAttempt" test would be made before attempting an authintication with another realm.