### PR TITLE
MK-1279 - add earliestStart and containerId properties to datasetVari…

### DIFF
--- a/mica-core/src/main/java/org/obiba/mica/dataset/domain/DatasetVariable.java
+++ b/mica-core/src/main/java/org/obiba/mica/dataset/domain/DatasetVariable.java
@@ -27,6 +27,7 @@ import org.obiba.mica.core.domain.LocalizedString;
 import org.obiba.mica.core.domain.NetworkTable;
 import org.obiba.mica.core.domain.OpalTable;
 import org.obiba.mica.core.domain.StudyTable;
+import org.obiba.mica.study.date.PersistableYearMonth;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Strings;
@@ -107,12 +108,17 @@ public class DatasetVariable implements Indexable, AttributeAware {
   @NotNull
   private LocalizedString datasetName;
 
+  private String earliestStart;
+
+  private String containerId;
+
   public DatasetVariable() {}
 
   public DatasetVariable(StudyDataset dataset, Variable variable) {
     this(dataset, Type.Study, variable);
     studyIds = Lists.newArrayList(dataset.getStudyTable().getStudyId());
     dceIds = Lists.newArrayList(dataset.getStudyTable().getDataCollectionEventUId());
+    setContainerId(studyIds.get(0));
   }
 
   public DatasetVariable(HarmonizationDataset dataset, Variable variable) {
@@ -127,6 +133,7 @@ public class DatasetVariable implements Indexable, AttributeAware {
     });
 
     networkId = dataset.getNetworkId();
+    setContainerId(networkId);
 
     dataset.getStudyTables().forEach(table -> {
       if(!dceIds.contains(table.getDataCollectionEventUId())) dceIds.add(table.getDataCollectionEventUId());
@@ -139,9 +146,11 @@ public class DatasetVariable implements Indexable, AttributeAware {
     if(opalTable instanceof StudyTable) {
       studyIds = Lists.newArrayList(((StudyTable) opalTable).getStudyId());
       dceIds = Lists.newArrayList(((StudyTable) opalTable).getDataCollectionEventUId());
+      setContainerId(studyIds.get(0));
       opalTableType = OpalTableType.Study;
     } else {
       networkTableIds = Lists.newArrayList(((NetworkTable) opalTable).getNetworkId());
+      setContainerId(networkId);
       opalTableType = OpalTableType.Network;
     }
 
@@ -322,6 +331,22 @@ public class DatasetVariable implements Indexable, AttributeAware {
     return getClass().getSimpleName();
   }
 
+  public String getEarliestStart() {
+    return earliestStart;
+  }
+
+  public void setEarliestStart(String earliestStart) {
+    this.earliestStart = earliestStart;
+  }
+
+  public String getContainerId() {
+    return containerId;
+  }
+
+  public void setContainerId(String containerId) {
+    this.containerId = cleanStringForSearch(containerId);
+  }
+
   /**
    * For Json deserialization.
    *
@@ -358,6 +383,10 @@ public class DatasetVariable implements Indexable, AttributeAware {
 
   public void setNetworkId(String networkId) {
     this.networkId = networkId;
+  }
+
+  private String cleanStringForSearch(String string) {
+    return string.replace("-", "");
   }
 
   public static class IdResolver {

--- a/mica-core/src/main/java/org/obiba/mica/study/date/PersistableYearMonth.java
+++ b/mica-core/src/main/java/org/obiba/mica/study/date/PersistableYearMonth.java
@@ -24,6 +24,7 @@ public class PersistableYearMonth implements Serializable, Comparable<Persistabl
   private static final MonthValidator MONTH_VALIDATOR = new MonthValidator();
 
   private String yearMonth;
+  private String sortableYearMonth;
 
   public interface YearMonthData {
     int getYear();
@@ -36,11 +37,16 @@ public class PersistableYearMonth implements Serializable, Comparable<Persistabl
     return yearMonth;
   }
 
+  public String getSortableYearMonth() {
+    return sortableYearMonth;
+  }
+
   public static PersistableYearMonth of(int y, int m) {
     PersistableYearMonth instance = new PersistableYearMonth();
     YEAR_VALIDATOR.validate(y);
     MONTH_VALIDATOR.validate(m);
     instance.yearMonth = format(y, m);
+    instance.sortableYearMonth = instance.yearMonth.replace("-", "");
     return instance;
   }
 
@@ -48,6 +54,7 @@ public class PersistableYearMonth implements Serializable, Comparable<Persistabl
     PersistableYearMonth instance = new PersistableYearMonth();
     YEAR_VALIDATOR.validate(y);
     instance.yearMonth = format(y);
+    instance.sortableYearMonth = instance.yearMonth;
     return instance;
   }
 
@@ -71,7 +78,7 @@ public class PersistableYearMonth implements Serializable, Comparable<Persistabl
       p = Pattern.compile("(\\d{4})");
       m = p.matcher(text);
 
-      if (!m.matches()) throw new IllegalArgumentException("Invalid YearMonth format, expectes YYYY-mm or YYYY: " + text);
+      if (!m.matches()) throw new IllegalArgumentException("Invalid YearMonth format, expected YYYY-mm or YYYY: " + text);
     }
 
     int year = Integer.valueOf(m.group(1));

--- a/mica-core/src/main/java/org/obiba/mica/study/domain/Population.java
+++ b/mica-core/src/main/java/org/obiba/mica/study/domain/Population.java
@@ -193,6 +193,10 @@ public class Population extends AbstractAttributeModelAware implements Serializa
     return super.getModel();
   }
 
+  public DataCollectionEvent findDataCollectionEvent(String id) {
+    return dataCollectionEvents.stream().filter(dce -> id.equals(dce.getId())).findFirst().orElse(null);
+  }
+
   public static class Recruitment implements Serializable {
 
     private static final long serialVersionUID = 7949265355598902080L;

--- a/mica-core/src/main/java/org/obiba/mica/study/domain/Study.java
+++ b/mica-core/src/main/java/org/obiba/mica/study/domain/Study.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -510,6 +511,10 @@ public class Study extends AbstractModelAware implements AttributeAware, PersonA
     }
 
     return super.getModel();
+  }
+
+  public Population findPopulation(String id) {
+    return populations.stream().filter(p -> id.equals(p.getId())).findFirst().orElse(null);
   }
 
   public static class StudyMethods implements Serializable {

--- a/mica-core/src/main/java/org/obiba/mica/study/service/StudyService.java
+++ b/mica-core/src/main/java/org/obiba/mica/study/service/StudyService.java
@@ -17,6 +17,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -43,6 +44,9 @@ import org.obiba.mica.network.NetworkRepository;
 import org.obiba.mica.study.ConstraintException;
 import org.obiba.mica.study.StudyRepository;
 import org.obiba.mica.study.StudyStateRepository;
+import org.obiba.mica.study.date.PersistableYearMonth;
+import org.obiba.mica.study.domain.DataCollectionEvent;
+import org.obiba.mica.study.domain.Population;
 import org.obiba.mica.study.domain.Study;
 import org.obiba.mica.study.domain.StudyState;
 import org.obiba.mica.study.event.DraftStudyUpdatedEvent;
@@ -180,6 +184,19 @@ public class StudyService extends AbstractGitPersistableService<StudyState, Stud
     }
 
     return study;
+  }
+
+  public PersistableYearMonth getPersistableYearMonthFor(Study study, String populationId, String dceId) {
+    if (study != null) {
+      Population population = study.getPopulations().stream().filter(p -> p.getId().equals(populationId)).findFirst()
+        .orElse(null);
+
+      return population != null ? population
+        .getDataCollectionEvents().stream().filter(dce -> dce.getId().equals(dceId)).findFirst()
+        .map(DataCollectionEvent::getStart).orElse(null) : null;
+    }
+
+    return null;
   }
 
   @NotNull

--- a/mica-search/src/main/java/org/obiba/mica/search/queries/AbstractDocumentQuery.java
+++ b/mica-search/src/main/java/org/obiba/mica/search/queries/AbstractDocumentQuery.java
@@ -378,6 +378,8 @@ public abstract class AbstractDocumentQuery {
 
     // apply default sort for VariableQuery before any user defined ones (order is important)
     if (this instanceof VariableQuery) {
+      requestBuilder.addSort(SortBuilders.fieldSort("containerId").order(SortOrder.ASC)); // either study or network id
+      requestBuilder.addSort(SortBuilders.fieldSort("earliestStart").order(SortOrder.ASC).unmappedType("string")); // only for study variable
       requestBuilder.addSort(SortBuilders.fieldSort("datasetId").order(SortOrder.ASC));
       requestBuilder.addSort(SortBuilders.fieldSort("index").order(SortOrder.ASC));
     }


### PR DESCRIPTION
…ables of type Study.

The variables will thus be ordered by:
1- study id or network id (in the case of dataschema variables)
2- dce start date (for study variables)
3- dataset id (useful for dataschema variables because dce start date is not set)
4- index

This way, a study variable is ordered chronologically within its study.