### PR TITLE
MK-1279 - add earliestStart and containerId properties to datasetVari…

### DIFF
--- a/mica-core/src/main/java/org/obiba/mica/dataset/domain/StudyDataset.java
+++ b/mica-core/src/main/java/org/obiba/mica/dataset/domain/StudyDataset.java
@@ -26,6 +26,8 @@ public class StudyDataset extends Dataset {
 
   private StudyTable studyTable;
 
+  private String start;
+
   public StudyTable getStudyTable() {
     return studyTable;
   }
@@ -52,5 +54,13 @@ public class StudyDataset extends Dataset {
         put(self.getClass().getSimpleName(), self);
       }
     };
+  }
+
+  public String getStart() {
+    return start;
+  }
+
+  public void setStart(String start) {
+    this.start = start;
   }
 }

--- a/mica-core/src/main/java/org/obiba/mica/dataset/service/StudyDatasetService.java
+++ b/mica-core/src/main/java/org/obiba/mica/dataset/service/StudyDatasetService.java
@@ -12,6 +12,7 @@ package org.obiba.mica.dataset.service;
 
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import javax.inject.Inject;
@@ -44,6 +45,8 @@ import org.obiba.mica.file.FileUtils;
 import org.obiba.mica.file.service.FileSystemService;
 import org.obiba.mica.micaConfig.service.OpalService;
 import org.obiba.mica.network.service.NetworkService;
+import org.obiba.mica.study.date.PersistableYearMonth;
+import org.obiba.mica.study.domain.Study;
 import org.obiba.mica.study.service.StudyService;
 import org.obiba.opal.rest.client.magma.RestValueTable;
 import org.obiba.opal.web.model.Search;
@@ -229,6 +232,32 @@ public class StudyDatasetService extends DatasetService<StudyDataset, StudyDatas
     eventBus.post(new StudyDatasetIndexedEvent());
   }
 
+  public List<DatasetVariable> processVariablesForStudyDataset(StudyDataset dataset, Iterable<DatasetVariable> variables) {
+    Study study = studyService.findStudy(dataset.getStudyTable().getStudyId());
+
+    PersistableYearMonth persistableYearMonth = studyService
+      .getPersistableYearMonthFor(study, dataset.getStudyTable().getPopulationId(),
+        dataset.getStudyTable().getDataCollectionEventId());
+
+    if (persistableYearMonth != null) {
+      dataset.setStart(persistableYearMonth.getSortableYearMonth());
+      return processVariablesForStudyDataset(persistableYearMonth, variables);
+    } else {
+      return Lists.newArrayList(variables);
+    }
+  }
+
+  private List<DatasetVariable> processVariablesForStudyDataset(
+    PersistableYearMonth persistableYearMonthFor, Iterable<DatasetVariable> variables) {
+    return StreamSupport.stream(variables.spliterator(), false)
+      .map(datasetVariable -> {
+        if(persistableYearMonthFor != null)
+          datasetVariable.setEarliestStart(persistableYearMonthFor.getSortableYearMonth());
+
+        return datasetVariable;
+      }).collect(toList());
+  }
+
   @Override
   @NotNull
   protected RestValueTable getTable(@NotNull StudyDataset dataset) throws NoSuchValueTableException {
@@ -240,7 +269,7 @@ public class StudyDatasetService extends DatasetService<StudyDataset, StudyDatas
   public Iterable<DatasetVariable> getDatasetVariables(StudyDataset dataset) {
     if (dataset.hasStudyTable()) {
       return StreamSupport.stream(getVariables(dataset).spliterator(), false)
-          .map(input -> new DatasetVariable(dataset, input)).collect(toList());
+        .map(input -> new DatasetVariable(dataset, input)).collect(toList());
     }
     return Lists.newArrayList();
   }

--- a/mica-core/src/main/java/org/obiba/mica/study/date/PersistableYearMonth.java
+++ b/mica-core/src/main/java/org/obiba/mica/study/date/PersistableYearMonth.java
@@ -24,6 +24,7 @@ public class PersistableYearMonth implements Serializable, Comparable<Persistabl
   private static final MonthValidator MONTH_VALIDATOR = new MonthValidator();
 
   private String yearMonth;
+  private String sortableYearMonth;
 
   public interface YearMonthData {
     int getYear();
@@ -36,11 +37,16 @@ public class PersistableYearMonth implements Serializable, Comparable<Persistabl
     return yearMonth;
   }
 
+  public String getSortableYearMonth() {
+    return sortableYearMonth;
+  }
+
   public static PersistableYearMonth of(int y, int m) {
     PersistableYearMonth instance = new PersistableYearMonth();
     YEAR_VALIDATOR.validate(y);
     MONTH_VALIDATOR.validate(m);
     instance.yearMonth = format(y, m);
+    instance.sortableYearMonth = instance.yearMonth.replace("-", "");
     return instance;
   }
 
@@ -48,6 +54,7 @@ public class PersistableYearMonth implements Serializable, Comparable<Persistabl
     PersistableYearMonth instance = new PersistableYearMonth();
     YEAR_VALIDATOR.validate(y);
     instance.yearMonth = format(y);
+    instance.sortableYearMonth = instance.yearMonth;
     return instance;
   }
 
@@ -71,7 +78,7 @@ public class PersistableYearMonth implements Serializable, Comparable<Persistabl
       p = Pattern.compile("(\\d{4})");
       m = p.matcher(text);
 
-      if (!m.matches()) throw new IllegalArgumentException("Invalid YearMonth format, expectes YYYY-mm or YYYY: " + text);
+      if (!m.matches()) throw new IllegalArgumentException("Invalid YearMonth format, expected YYYY-mm or YYYY: " + text);
     }
 
     int year = Integer.valueOf(m.group(1));

--- a/mica-core/src/main/java/org/obiba/mica/study/domain/Study.java
+++ b/mica-core/src/main/java/org/obiba/mica/study/domain/Study.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -510,6 +511,10 @@ public class Study extends AbstractModelAware implements AttributeAware, PersonA
     }
 
     return super.getModel();
+  }
+
+  public Population findPopulation(String id) {
+    return populations.stream().filter(p -> p.getId().equals(id)).findFirst().orElse(null);
   }
 
   public static class StudyMethods implements Serializable {

--- a/mica-core/src/main/java/org/obiba/mica/study/service/StudyService.java
+++ b/mica-core/src/main/java/org/obiba/mica/study/service/StudyService.java
@@ -17,6 +17,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -43,6 +44,9 @@ import org.obiba.mica.network.NetworkRepository;
 import org.obiba.mica.study.ConstraintException;
 import org.obiba.mica.study.StudyRepository;
 import org.obiba.mica.study.StudyStateRepository;
+import org.obiba.mica.study.date.PersistableYearMonth;
+import org.obiba.mica.study.domain.DataCollectionEvent;
+import org.obiba.mica.study.domain.Population;
 import org.obiba.mica.study.domain.Study;
 import org.obiba.mica.study.domain.StudyState;
 import org.obiba.mica.study.event.DraftStudyUpdatedEvent;
@@ -180,6 +184,18 @@ public class StudyService extends AbstractGitPersistableService<StudyState, Stud
     }
 
     return study;
+  }
+
+  public PersistableYearMonth getPersistableYearMonthFor(Study study, String populationId, String dceId) {
+    if (study != null) {
+      Population population = study.findPopulation(populationId);
+
+      return population != null ? population
+        .getDataCollectionEvents().stream().filter(dce -> dce.getId().equals(dceId)).findFirst()
+        .map(DataCollectionEvent::getStart).orElse(null) : null;
+    }
+
+    return null;
   }
 
   @NotNull

--- a/mica-search/src/main/java/org/obiba/mica/search/queries/AbstractDocumentQuery.java
+++ b/mica-search/src/main/java/org/obiba/mica/search/queries/AbstractDocumentQuery.java
@@ -378,8 +378,17 @@ public abstract class AbstractDocumentQuery {
 
     // apply default sort for VariableQuery before any user defined ones (order is important)
     if (this instanceof VariableQuery) {
+      requestBuilder.addSort(SortBuilders.fieldSort("containerId").order(SortOrder.ASC).unmappedType("string")); // either study or network id
+      requestBuilder.addSort(SortBuilders.fieldSort("populationIds").order(SortOrder.ASC).unmappedType("string"));
+      requestBuilder.addSort(SortBuilders.fieldSort("earliestStart").order(SortOrder.ASC).unmappedType("string")); // only for study variable
       requestBuilder.addSort(SortBuilders.fieldSort("datasetId").order(SortOrder.ASC));
       requestBuilder.addSort(SortBuilders.fieldSort("index").order(SortOrder.ASC));
+    }
+
+    if (this instanceof DatasetQuery) {
+      requestBuilder.addSort(SortBuilders.fieldSort("studyTable.studyId").order(SortOrder.ASC).unmappedType("string"));
+      requestBuilder.addSort(SortBuilders.fieldSort("studyTable.populationId").order(SortOrder.ASC).unmappedType("string"));
+      requestBuilder.addSort(SortBuilders.fieldSort("start").order(SortOrder.ASC).unmappedType("string").unmappedType("string"));
     }
 
     if(sortBuilder != null) sortBuilder.forEach(requestBuilder::addSort);


### PR DESCRIPTION
…ables of type Study.

The variables will thus be ordered by:
1- study id or network id (in the case of dataschema variables)
2- dce start date (for study variables)
3- dataset id (useful for dataschema variables because dce start date is not set)
4- index

This way, a study variable is ordered chronologically within its study.

The same variable value for earliestStart is used in dataset to order them chronologically (first group datsets by study id then use dce's start date to order them further).