### PR TITLE
potential fix for opal-taxonomies cahce clearing at application resta…

### DIFF
--- a/mica-core/src/main/resources/ehcache.xml
+++ b/mica-core/src/main/resources/ehcache.xml
@@ -66,6 +66,8 @@
       timeToIdleSeconds="0"/>
 
   <cache name="opal-taxonomies"
+    maxBytesLocalHeap="1M"
+    diskPersistent="true"
     overflowToDisk="true"
     eternal="true">
     <sizeOfPolicy maxDepth="100000"/>


### PR DESCRIPTION
…rt and after ~24 hours.

The documentation advises that every cache must have a local-heap setting (http://www.ehcache.org/documentation/ehcache-2.6.x-documentation.pdf [page 64]) in order to avoidInvalidConfigurationException.

In order for the cache to be eternal, I opted to use diskpersistence (http://www.ehcache.org/documentation/2.7/configuration/fast-restart.html) where both overflowToDisk and diskPersistent attributes are set to true. 
This config definitely avoids the opal-taxonomies cache clear after a restart. Couldn't test for the ~24 hour clearing though.