### PR TITLE
MK-1433 - fix datasetCountStats to be more inline with join query result hit counts

### DIFF
--- a/mica-search/src/main/java/org/obiba/mica/search/JoinQueryExecutor.java
+++ b/mica-search/src/main/java/org/obiba/mica/search/JoinQueryExecutor.java
@@ -410,10 +410,12 @@ public class JoinQueryExecutor {
     CountStatsData countStats = null;
     switch(type) {
       case DATASET:
-        countStats = CountStatsData.newBuilder().variables(variableQuery.getDatasetCounts()) //
-            .studyVariables(variableQuery.getStudyVariableByDatasetCounts()) //
-            .dataschemaVariables(variableQuery.getDataschemaVariableByDatasetCounts()) //
-            .studies(studyQuery.getStudyCounts()) //
+        countStats = CountStatsData.newBuilder().variables(variableQuery.getDatasetCounts())
+            .studyVariables(variableQuery.getStudyVariableByDatasetCounts())
+            .dataschemaVariables(variableQuery.getDataschemaVariableByDatasetCounts())
+            .studies(studyQuery.getStudyCounts())
+            .individualStudies(studyQuery.getIndividualStudyCounts())
+            .harmonizationStudies(studyQuery.getHarmonizationStudyCounts())
             .networksMap(networkQuery.getStudyCountsByNetwork()).build();
         break;
       case STUDY:


### PR DESCRIPTION
A harmonizaed dataset is linked to one and only one harmonization study.

One observation is that the lists of harmonization and study tables are not at all reflected int the search.