### PR TITLE
Bugfix - filter opal tables by access permission for a harmonization study detail

### DIFF
--- a/mica-web-model/src/main/java/org/obiba/mica/web/model/DatasetDtos.java
+++ b/mica-web-model/src/main/java/org/obiba/mica/web/model/DatasetDtos.java
@@ -134,12 +134,16 @@ class DatasetDtos {
     }
 
     if(!dataset.getStudyTables().isEmpty()) {
-      dataset.getStudyTables().forEach(studyTable -> hbuilder
+      dataset.getStudyTables()
+        .stream().filter(studyTable -> isStudyTablePermitted(asDraft, "individual", studyTable.getStudyId()))
+        .forEach(studyTable -> hbuilder
         .addStudyTables(asDto(studyTable, true)));
     }
 
     if (!dataset.getHarmonizationTables().isEmpty()) {
-      dataset.getHarmonizationTables().forEach(harmonizationTable -> hbuilder
+      dataset.getHarmonizationTables()
+        .stream().filter(studyTable -> isStudyTablePermitted(asDraft, "harmonization", studyTable.getStudyId()))
+        .forEach(harmonizationTable -> hbuilder
         .addHarmonizationTables(asDto(harmonizationTable, true)));
     }
 
@@ -158,6 +162,11 @@ class DatasetDtos {
     builder.setPermissions(permissionsDto);
 
     return builder;
+  }
+
+  public boolean isStudyTablePermitted(boolean asDraft, String type, String id) {
+    return (asDraft && subjectAclService.isPermitted(String.format("/draft/%s-study", type), "VIEW", id)) ||
+      subjectAclService.isAccessible(String.format("/%s-study", type), id);
   }
 
   @NotNull

--- a/mica-web-model/src/main/java/org/obiba/mica/web/model/StudyDtos.java
+++ b/mica-web-model/src/main/java/org/obiba/mica/web/model/StudyDtos.java
@@ -83,8 +83,13 @@ class StudyDtos {
   Mica.StudyDto asDto(@NotNull HarmonizationStudy study, boolean asDraft, List<HarmonizationDataset> datasets) {
     Mica.HarmonizationStudyDto.Builder hStudyBuilder = Mica.HarmonizationStudyDto.newBuilder();
     HarmonizationDatasetHelper.TablesMerger tableMerger = HarmonizationDatasetHelper.newTablesMerger(datasets);
-    tableMerger.getStudyTables().forEach(st -> hStudyBuilder.addStudyTables(datasetDtos.asDto(st, true)));
-    tableMerger.getHarmonizationStudyTables().forEach(st -> hStudyBuilder.addHarmonizationTables(datasetDtos.asDto(st, true)));
+    tableMerger.getStudyTables()
+      .stream().filter(studyTable -> datasetDtos.isStudyTablePermitted(asDraft, "individual", studyTable.getStudyId()))
+      .forEach(st -> hStudyBuilder.addStudyTables(datasetDtos.asDto(st, true)));
+
+    tableMerger.getHarmonizationStudyTables()
+      .stream().filter(studyTable -> datasetDtos.isStudyTablePermitted(asDraft, "harmonization", studyTable.getStudyId()))
+      .forEach(st -> hStudyBuilder.addHarmonizationTables(datasetDtos.asDto(st, true)));
 
     Mica.StudyDto.Builder builder = asDtoBuilder(study, asDraft);
     builder.setExtension(Mica.HarmonizationStudyDto.type, hStudyBuilder.build());


### PR DESCRIPTION
Same is done for opal tables for a harmonized dataset.