### PR TITLE
MK-1651 Entities count web service added for collected variables only

### DIFF
--- a/mica-core/src/main/java/org/obiba/mica/dataset/domain/HarmonizationDataset.java
+++ b/mica-core/src/main/java/org/obiba/mica/dataset/domain/HarmonizationDataset.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
+import org.obiba.mica.core.domain.BaseStudyTable;
 import org.obiba.mica.core.domain.HarmonizationStudyTable;
 import org.obiba.mica.core.domain.OpalTable;
 import org.obiba.mica.core.domain.StudyTable;
@@ -103,7 +104,7 @@ public class HarmonizationDataset extends Dataset {
   }
 
   @JsonIgnore
-  public List<OpalTable> getAllOpalTables() {
+  public List<BaseStudyTable> getBaseStudyTables() {
     return Lists.newArrayList(Iterables.concat(getStudyTables(), getHarmonizationTables())).stream()//
       .sorted(Comparator.comparingInt(OpalTable::getWeight)).collect(Collectors.toList());
   }

--- a/mica-core/src/main/java/org/obiba/mica/micaConfig/service/CacheService.java
+++ b/mica-core/src/main/java/org/obiba/mica/micaConfig/service/CacheService.java
@@ -13,7 +13,6 @@ package org.obiba.mica.micaConfig.service;
 import javax.inject.Inject;
 
 import org.obiba.magma.NoSuchVariableException;
-import org.obiba.mica.core.domain.BaseStudyTable;
 import org.obiba.mica.dataset.domain.Dataset;
 import org.obiba.mica.dataset.service.CollectedDatasetService;
 import org.obiba.mica.dataset.service.HarmonizedDatasetService;
@@ -105,8 +104,8 @@ public class CacheService {
     public void buildDatasetVariablesCache() {
       harmonizedDatasetService.findAllPublishedDatasets().forEach(
         dataset -> harmonizedDatasetService.getDatasetVariables(dataset)
-          .forEach(v -> dataset.getAllOpalTables().forEach(st -> {
-            String studyId = ((BaseStudyTable)st).getStudyId();
+          .forEach(v -> dataset.getBaseStudyTables().forEach(st -> {
+            String studyId = st.getStudyId();
             try {
               harmonizedDatasetService
                 .getVariableSummary(dataset, v.getName(), studyId, st.getProject(), st.getTable());

--- a/mica-core/src/main/java/org/obiba/mica/micaConfig/service/helper/OpalServiceHelper.java
+++ b/mica-core/src/main/java/org/obiba/mica/micaConfig/service/helper/OpalServiceHelper.java
@@ -23,6 +23,7 @@ import org.obiba.mica.micaConfig.event.OpalTaxonomiesUpdatedEvent;
 import org.obiba.opal.core.domain.taxonomy.Taxonomy;
 import org.obiba.opal.rest.client.magma.OpalJavaClient;
 import org.obiba.opal.web.model.Opal;
+import org.obiba.opal.web.model.Search;
 import org.obiba.opal.web.taxonomy.Dtos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,6 +51,16 @@ public class OpalServiceHelper {
     ConcurrentMap<String, Taxonomy> taxonomiesList = taxonomies.stream().collect(Collectors.toConcurrentMap(Opal.TaxonomyDto::getName, this::fromDto));
     eventBus.post(new OpalTaxonomiesUpdatedEvent(taxonomiesList));
     return taxonomiesList;
+  }
+
+  public Search.EntitiesResultDto getEntitiesCount(OpalJavaClient opalJavaClient, String query, String entityType) {
+    log.info("Fetching opal entities count");
+    log.debug("  Entities query: {}", query);
+    URI uri = opalJavaClient.newUri().segment("datasources", "entities", "_count")
+        .query("query", query)
+        .query("type", Strings.isNullOrEmpty(entityType) ? "Participant" : entityType).build();
+    Search.EntitiesResultDto result = opalJavaClient.getResource(Search.EntitiesResultDto.class, uri, Search.EntitiesResultDto.newBuilder());
+    return result;
   }
 
   /**

--- a/mica-core/src/main/java/org/obiba/mica/web/model/DocumentDigestDtos.java
+++ b/mica-core/src/main/java/org/obiba/mica/web/model/DocumentDigestDtos.java
@@ -16,6 +16,7 @@ import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
 
 import org.obiba.mica.dataset.domain.Dataset;
+import org.obiba.mica.dataset.domain.DatasetVariable;
 import org.obiba.mica.network.domain.Network;
 import org.obiba.mica.study.domain.BaseStudy;
 import org.obiba.mica.study.domain.Study;
@@ -42,13 +43,26 @@ public class DocumentDigestDtos {
   }
 
   @NotNull
+  public DocumentDigestDto.Builder asDtoBuilder(@NotNull DatasetVariable variable) {
+    DocumentDigestDto.Builder builder = DocumentDigestDto.newBuilder().setId(variable.getId());
+    if (variable.getAttributes().hasAttribute("label", null))
+      builder.addAllName(localizedStringDtos.asDto(variable.getAttributes().getAttribute("label", null).getValues()));
+    return builder;
+  }
+
+  @NotNull
+  public DocumentDigestDto asDto(@NotNull DatasetVariable variable) {
+    return asDtoBuilder(variable).build();
+  }
+
+  @NotNull
   public DocumentDigestDto.Builder asDtoBuilder(@NotNull BaseStudy study) {
     return DocumentDigestDto.newBuilder().setId(study.getId()) //
         .addAllName(localizedStringDtos.asDto(study.getName()));
   }
 
   @NotNull
-  public DocumentDigestDto asDto(@NotNull Study study) {
+  public DocumentDigestDto asDto(@NotNull BaseStudy study) {
     return asDtoBuilder(study).build();
   }
 

--- a/mica-rest/pom.xml
+++ b/mica-rest/pom.xml
@@ -108,6 +108,12 @@
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>net.jazdw</groupId>
+      <artifactId>rql-parser</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.glassfish.jersey.test-framework.providers</groupId>
       <artifactId>jersey-test-framework-provider-inmemory</artifactId>

--- a/mica-rest/src/main/java/org/obiba/mica/dataset/rest/PublishedDatasetsEntitiesResource.java
+++ b/mica-rest/src/main/java/org/obiba/mica/dataset/rest/PublishedDatasetsEntitiesResource.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2017 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.obiba.mica.dataset.rest;
+
+import com.codahale.metrics.annotation.Timed;
+import com.google.common.collect.Lists;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.obiba.mica.dataset.rest.rql.RQLCriteriaOpalConverter;
+import org.obiba.mica.dataset.rest.rql.RQLCriterionOpalConverter;
+import org.obiba.mica.micaConfig.service.OpalService;
+import org.obiba.mica.web.model.DocumentDigestDtos;
+import org.obiba.mica.web.model.MicaSearch;
+import org.obiba.opal.web.model.Search;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+@Path("/datasets/entities")
+@Scope("request")
+@RequiresAuthentication
+public class PublishedDatasetsEntitiesResource {
+
+  @Inject
+  private ApplicationContext applicationContext;
+
+  @Inject
+  private OpalService opalService;
+
+  @Inject
+  private DocumentDigestDtos documentDigestDtos;
+
+  @GET
+  @Path("_count")
+  @Timed
+  public MicaSearch.EntitiesCountDto countEntities(@QueryParam("query") String query, @QueryParam("type") @DefaultValue("Participant") String entityType) {
+    RQLCriteriaOpalConverter converter = applicationContext.getBean(RQLCriteriaOpalConverter.class);
+    converter.parse(query);
+    Map<String, List<RQLCriterionOpalConverter>> opalConverters = converter.getCriterionConverters().stream()
+        .collect(Collectors.groupingBy(c -> c.getTable().getOpal()));
+    List<OpalEntitiesQuery> opalEntitiesQueries = opalConverters.keySet().stream()
+        .map(opalUrl -> new OpalEntitiesQuery(entityType, opalUrl, opalConverters.get(opalUrl)))
+        .collect(Collectors.toList());
+
+    MicaSearch.EntitiesCountDto.Builder builder = MicaSearch.EntitiesCountDto.newBuilder()
+        .setEntityType(entityType).setQuery(query);
+
+    int total = -1;
+    for (OpalEntitiesQuery opalEntitiesQuery : opalEntitiesQueries) {
+      total = total<0 ? opalEntitiesQuery.getTotal() : 0;
+      builder.addAllCounts(opalEntitiesQuery.getDatasetEntitiesCounts());
+    }
+    builder.setTotal(total);
+
+    return builder.build();
+  }
+
+  private class OpalEntitiesQuery {
+    private final String entityType;
+    private final String opalUrl;
+    private final List<RQLCriterionOpalConverter> opalConverters;
+    private final Search.EntitiesResultDto opalResults;
+
+    private OpalEntitiesQuery(String entityType, String opalUrl, List<RQLCriterionOpalConverter> opalConverters) {
+      this.entityType = entityType;
+      this.opalUrl = opalUrl;
+      this.opalConverters = opalConverters;
+      this.opalResults = opalService.getEntitiesCount(opalUrl, getOpalQuery(), entityType);
+    }
+
+    private String getOpalQuery() {
+      return opalConverters.stream().map(RQLCriterionOpalConverter::getOpalQuery).collect(Collectors.joining(","));
+    }
+
+    private String getMicaQuery() {
+      return opalConverters.stream().map(RQLCriterionOpalConverter::getMicaQuery).collect(Collectors.joining(","));
+    }
+
+    private int getTotal() {
+      return opalResults.getTotalHits();
+    }
+
+    public String getEntityType() {
+      return entityType;
+    }
+
+    public List<MicaSearch.DatasetEntitiesCountDto> getDatasetEntitiesCounts() {
+      List<MicaSearch.DatasetEntitiesCountDto> counts;
+      if (opalResults.getPartialResultsCount()>0)
+        counts = opalResults.getPartialResultsList().stream().map(this::createDatasetEntitiesCount).collect(Collectors.toList());
+      else
+        counts = Lists.newArrayList(createDatasetEntitiesCount(opalResults));
+      return counts;
+    }
+
+    private MicaSearch.DatasetEntitiesCountDto createDatasetEntitiesCount(Search.EntitiesResultDto opalResult) {
+      MicaSearch.DatasetEntitiesCountDto.Builder builder = MicaSearch.DatasetEntitiesCountDto.newBuilder()
+          .setCount(opalResult.getTotalHits());
+      RQLCriterionOpalConverter converter = findConverter(opalResult.getQuery());
+      builder.setQuery(converter.getMicaQuery())
+          .setVariable(documentDigestDtos.asDto(converter.getTable().getVariable()))
+          .setDataset(documentDigestDtos.asDto(converter.getTable().getDataset()))
+          .setStudy(documentDigestDtos.asDto(converter.getTable().getStudy()));
+      return builder.build();
+    }
+
+    private RQLCriterionOpalConverter findConverter(String opalQuery) {
+      return opalConverters.stream().filter(c -> c.getOpalQuery().equals(opalQuery)).findFirst().get();
+    }
+
+  }
+}

--- a/mica-rest/src/main/java/org/obiba/mica/dataset/rest/harmonization/DraftDataschemaDatasetVariableResource.java
+++ b/mica-rest/src/main/java/org/obiba/mica/dataset/rest/harmonization/DraftDataschemaDatasetVariableResource.java
@@ -18,7 +18,6 @@ import javax.ws.rs.Path;
 
 import org.obiba.magma.NoSuchValueTableException;
 import org.obiba.magma.NoSuchVariableException;
-import org.obiba.mica.core.domain.BaseStudyTable;
 import org.obiba.mica.dataset.DatasetVariableResource;
 import org.obiba.mica.dataset.domain.HarmonizationDataset;
 import org.obiba.mica.dataset.service.HarmonizedDatasetService;
@@ -55,9 +54,9 @@ public class DraftDataschemaDatasetVariableResource implements DatasetVariableRe
   public List<Math.SummaryStatisticsDto> getVariableSummaries() {
     ImmutableList.Builder<Math.SummaryStatisticsDto> builder = ImmutableList.builder();
     HarmonizationDataset dataset = getDataset();
-    dataset.getAllOpalTables().forEach(table -> {
+    dataset.getBaseStudyTables().forEach(table -> {
       try {
-        String studyId = ((BaseStudyTable)table).getStudyId();
+        String studyId = table.getStudyId();
         builder.add(datasetService
           .getVariableSummary(dataset, variableName, studyId, table.getProject(), table.getTable())
           .getWrappedDto());
@@ -73,9 +72,9 @@ public class DraftDataschemaDatasetVariableResource implements DatasetVariableRe
   public List<Search.QueryResultDto> getVariableFacets() {
     ImmutableList.Builder<Search.QueryResultDto> builder = ImmutableList.builder();
     HarmonizationDataset dataset = getDataset();
-    dataset.getAllOpalTables().forEach(table -> {
+    dataset.getBaseStudyTables().forEach(table -> {
       try {
-        String studyId = ((BaseStudyTable)table).getStudyId();
+        String studyId = table.getStudyId();
         builder.add(datasetService.getVariableFacet(dataset, variableName, studyId, table.getProject(), table.getTable()));
       } catch(NoSuchVariableException | NoSuchValueTableException e) {
         // ignore (case the study has not implemented this dataschema variable)
@@ -89,7 +88,7 @@ public class DraftDataschemaDatasetVariableResource implements DatasetVariableRe
   public List<Mica.DatasetVariableDto> getHarmonizedVariables() {
     ImmutableList.Builder<Mica.DatasetVariableDto> builder = ImmutableList.builder();
     HarmonizationDataset dataset = getDataset();
-    dataset.getAllOpalTables().forEach(table -> {
+    dataset.getBaseStudyTables().forEach(table -> {
       try {
         builder.add(dtos.asDto(datasetService.getDatasetVariable(dataset, variableName, table)));
       } catch(NoSuchVariableException | NoSuchValueTableException e) {

--- a/mica-rest/src/main/java/org/obiba/mica/dataset/rest/harmonization/DraftHarmonizedDatasetResource.java
+++ b/mica-rest/src/main/java/org/obiba/mica/dataset/rest/harmonization/DraftHarmonizedDatasetResource.java
@@ -13,7 +13,7 @@ package org.obiba.mica.dataset.rest.harmonization;
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.ImmutableList;
 import org.obiba.mica.AbstractGitPersistableResource;
-import org.obiba.mica.core.domain.OpalTable;
+import org.obiba.mica.core.domain.BaseStudyTable;
 import org.obiba.mica.core.domain.PublishCascadingScope;
 import org.obiba.mica.core.domain.RevisionStatus;
 import org.obiba.mica.core.service.AbstractGitPersistableService;
@@ -169,7 +169,7 @@ public class DraftHarmonizedDatasetResource extends
     checkPermission("/draft/harmonized-dataset", "VIEW");
     ImmutableList.Builder<Search.QueryResultDto> builder = ImmutableList.builder();
     HarmonizationDataset dataset = getDataset();
-    for(OpalTable table : dataset.getAllOpalTables()) {
+    for(BaseStudyTable table : dataset.getBaseStudyTables()) {
       builder.add(datasetService.getFacets(query, table));
     }
     return builder.build();

--- a/mica-rest/src/main/java/org/obiba/mica/dataset/rest/rql/RQLCriteriaOpalConverter.java
+++ b/mica-rest/src/main/java/org/obiba/mica/dataset/rest/rql/RQLCriteriaOpalConverter.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2017 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.obiba.mica.dataset.rest.rql;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import net.jazdw.rql.parser.ASTNode;
+import net.jazdw.rql.parser.RQLParser;
+import org.joda.time.DateTime;
+import org.obiba.magma.NoSuchVariableException;
+import org.obiba.magma.ValueType;
+import org.obiba.magma.support.VariableNature;
+import org.obiba.magma.type.TextType;
+import org.obiba.mica.core.domain.BaseStudyTable;
+import org.obiba.mica.dataset.domain.DatasetVariable;
+import org.obiba.mica.dataset.domain.HarmonizationDataset;
+import org.obiba.mica.dataset.domain.StudyDataset;
+import org.obiba.mica.dataset.service.CollectedDatasetService;
+import org.obiba.mica.dataset.service.HarmonizedDatasetService;
+import org.obiba.mica.spi.search.Indexer;
+import org.obiba.mica.spi.search.Searcher;
+import org.obiba.mica.study.domain.BaseStudy;
+import org.obiba.mica.study.service.StudyService;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.SimpleDateFormat;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Converts from RQL query from Mica to Opal.
+ */
+@Component
+@Scope("prototype")
+public class RQLCriteriaOpalConverter {
+
+  private final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+
+  @Inject
+  private CollectedDatasetService collectedDatasetService;
+
+  @Inject
+  private HarmonizedDatasetService harmonizedDatasetService;
+
+  @Inject
+  private StudyService studyService;
+
+  @Inject
+  protected Searcher searcher;
+
+  @Inject
+  protected ObjectMapper objectMapper;
+
+  /**
+   * RQL query object.
+   */
+  private ASTNode queryNode;
+
+  /**
+   * Original RQL query string.
+   */
+  private String rqlQuery;
+
+  /**
+   * RQL criterion list.
+   */
+  private List<RQLCriterionOpalConverter> criterionConverters = Lists.newArrayList();
+
+  public RQLCriteriaOpalConverter() {
+  }
+
+  public void parse(String rqlQuery) {
+    this.rqlQuery = rqlQuery;
+    RQLParser parser = new RQLParser();
+    this.queryNode = parser.parse(rqlQuery);
+    parseNode(queryNode);
+  }
+
+  public String getOriginalQuery() {
+    return rqlQuery;
+  }
+
+  public List<RQLCriterionOpalConverter> getCriterionConverters() {
+    return criterionConverters;
+  }
+
+  private String toString(ASTNode node) {
+    StringBuilder builder = new StringBuilder(node.getName()).append("(");
+    for (int i = 0; i < node.getArgumentsSize(); i++) {
+      if (i > 0) builder.append(",");
+      append(builder, node.getArgument(i));
+    }
+    builder.append(")");
+    return builder.toString();
+  }
+
+  private void append(StringBuilder builder, Object arg) {
+    if (arg instanceof ASTNode) builder.append(toString((ASTNode) arg));
+    else if (arg instanceof Collection) {
+      builder.append("(");
+      Collection<?> values = (Collection) arg;
+      int i = 0;
+      for (Object value : values) {
+        if (i > 0) builder.append(",");
+        append(builder, value);
+        i++;
+      }
+      builder.append(")");
+    } else if (arg instanceof DateTime) builder.append(normalizeDate((DateTime) arg));
+    else builder.append(arg);
+  }
+
+  private void parseNode(ASTNode node) {
+    if (Strings.isNullOrEmpty(node.getName()))
+      parseNodes(node.getArguments());
+    else
+      parseNode(node, false);
+  }
+
+  private void parseNode(ASTNode node, boolean not) {
+    RQLFieldReferences references = parseField(node.getArgument(0).toString());
+
+    switch (node.getName()) {
+      case "not":
+        parseNode((ASTNode) node.getArgument(0), true);
+      case "exists":
+      case "all":
+        criterionConverters.add(RQLCriterionOpalConverter.newBuilder(node)
+            .references(references).not(not).build());
+        break;
+      case "in":
+      case "like":
+        criterionConverters.add(RQLCriterionOpalConverter.newBuilder(node)
+            .references(references).value(parseValue(node.getArgument(1))).not(not).build());
+        break;
+      case "range":
+        criterionConverters.add(RQLCriterionOpalConverter.newBuilder(node)
+            .references(references).value(parseRange(node.getArgument(1))).not(not).build());
+        break;
+    }
+  }
+
+  protected RQLFieldReferences parseField(String path) {
+    // TODO translate mica variable to opal server + variable
+    DatasetVariable.IdResolver resolver = DatasetVariable.IdResolver.from(path);
+    if (resolver.getType() == null || DatasetVariable.Type.Collected.equals(resolver.getType())) {
+      StudyDataset ds = collectedDatasetService.findById(resolver.getDatasetId());
+      BaseStudyTable studyTable = ds.getStudyTable();
+      BaseStudy study = studyService.findStudy(studyTable.getStudyId());
+      return new RQLFieldReferences(path, ds, studyTable, study, getDatasetVariableInternal(Indexer.VARIABLE_TYPE, path));
+    } else if (DatasetVariable.Type.Dataschema.equals(resolver.getType())) {
+      HarmonizationDataset ds = harmonizedDatasetService.findById(resolver.getDatasetId());
+      ds.getBaseStudyTables();
+      // TODO
+    } else if (DatasetVariable.Type.Harmonized.equals(resolver.getType())) {
+      HarmonizationDataset ds = harmonizedDatasetService.findById(resolver.getDatasetId());
+      ds.getBaseStudyTables();
+      // TODO
+    }
+    throw new IllegalArgumentException("Not a valid variable: " + path);
+  }
+
+  protected ValueType getValueType() {
+    return TextType.get();
+  }
+
+  protected VariableNature getNature() {
+    return VariableNature.UNDETERMINED;
+  }
+
+  protected String join(String on, Collection<?> args) {
+    String nOn = on;
+    boolean toQuote = getNature().equals(VariableNature.CATEGORICAL);
+    List<String> nArgs = args.stream().map(arg -> {
+      String nArg = arg instanceof DateTime ? normalizeDate((DateTime) arg) : arg.toString();
+      if (toQuote) return quote(nArg);
+      else return normalizeString(nArg);
+    }).collect(Collectors.toList());
+
+    return Joiner.on(nOn).join(nArgs);
+  }
+
+  //
+  // Private methods
+  //
+
+  private String parseValue(Object value) {
+    if (value instanceof ASTNode) return toString((ASTNode) value);
+    if (value instanceof Collection) {
+      Collection<?> values = (Collection) value;
+      if (values.size() == 1 && getValueType().isDateTime()) return parseSingleDate(values.iterator().next());
+      return parseValues(values);
+    }
+    if (value instanceof DateTime) return parseSingleDate(value);
+    return getNature().equals(VariableNature.CATEGORICAL) ? quote(value) : normalizeString(value.toString());
+  }
+
+  private String normalizeString(String str) {
+    return str.replaceAll(" ", "+");
+  }
+
+  private String normalizeDate(DateTime date) {
+    return DATE_FORMAT.format(date.toDate());
+  }
+
+  private String quote(Object value) {
+    String valueStr = value.toString();
+    return valueStr.contains("*") ? normalizeString(valueStr) : "\"" + valueStr + "\"";
+  }
+
+  private String parseRange(Object value) {
+    if (value instanceof Collection) {
+      return join(",", (Collection) value);
+    }
+    return value + ",*";
+  }
+
+  private String parseSingleDate(Object value) {
+    if (value instanceof DateTime) {
+      String dateString = DATE_FORMAT.format(((DateTime) value).toDate());
+      return ">=" + dateString + " AND " + "<=" + dateString;
+    }
+    return normalizeString(value.toString());
+  }
+
+  private void parseNodes(Collection<?> args) {
+    args.forEach(arg -> parseNode((ASTNode) arg));
+  }
+
+  private String parseValues(Collection<?> args) {
+    return join(",", args);
+  }
+
+
+  private DatasetVariable getDatasetVariableInternal(String indexType, String variableId) {
+    InputStream inputStream = searcher.getDocumentById(Indexer.PUBLISHED_VARIABLE_INDEX, indexType, variableId);
+    if (inputStream == null) throw new NoSuchVariableException(variableId);
+    try {
+      return objectMapper.readValue(inputStream, DatasetVariable.class);
+    } catch (IOException e) {
+      throw new NoSuchVariableException(variableId);
+    }
+  }
+
+}

--- a/mica-rest/src/main/java/org/obiba/mica/dataset/rest/rql/RQLCriterionOpalConverter.java
+++ b/mica-rest/src/main/java/org/obiba/mica/dataset/rest/rql/RQLCriterionOpalConverter.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2017 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.obiba.mica.dataset.rest.rql;
+
+import com.google.common.base.Strings;
+import net.jazdw.rql.parser.ASTNode;
+
+public class RQLCriterionOpalConverter {
+
+  private String function;
+
+  private boolean not = false;
+
+  private String value;
+
+  private RQLFieldReferences variableReferences;
+
+  private RQLCriterionOpalConverter() {}
+
+  private String getQuery(String field) {
+    String query = function + "(" + field;
+    if (Strings.isNullOrEmpty(value))
+      query = query + ")";
+    else
+      query = query + ",(" + value + "))";
+    return not ? "not(" + query + ")" : query;
+  }
+
+  public String getOpalQuery() {
+    return getQuery(variableReferences.getOpalVariableReference());
+  }
+
+  public String getMicaQuery() {
+    return getQuery(variableReferences.getMicaVariableReference());
+  }
+
+  public RQLFieldReferences getTable() {
+    return variableReferences;
+  }
+
+  public static Builder newBuilder(ASTNode node) {
+    return new Builder(node);
+  }
+
+  public static class Builder {
+
+    private final RQLCriterionOpalConverter criterion;
+
+    public Builder(ASTNode node) {
+      criterion = new RQLCriterionOpalConverter();
+      criterion.function = node.getName();
+    }
+
+    public Builder references(RQLFieldReferences variableReferences) {
+      criterion.variableReferences = variableReferences;
+      return this;
+    }
+    public Builder value(String value) {
+      criterion.value = value;
+      return this;
+    }
+
+    public Builder not(boolean not) {
+      criterion.not = not;
+      return this;
+    }
+
+    public RQLCriterionOpalConverter build() {
+      return criterion;
+    }
+
+  }
+
+}

--- a/mica-rest/src/main/java/org/obiba/mica/dataset/rest/rql/RQLFieldReferences.java
+++ b/mica-rest/src/main/java/org/obiba/mica/dataset/rest/rql/RQLFieldReferences.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2017 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.obiba.mica.dataset.rest.rql;
+
+import com.google.common.base.Strings;
+import org.obiba.mica.core.domain.BaseStudyTable;
+import org.obiba.mica.dataset.domain.Dataset;
+import org.obiba.mica.dataset.domain.DatasetVariable;
+import org.obiba.mica.study.domain.BaseStudy;
+
+/**
+ * Various references associated to a Mica field query.
+ */
+public class RQLFieldReferences {
+  private final DatasetVariable variable;
+  private final Dataset dataset;
+  private final BaseStudyTable studyTable;
+  private final BaseStudy study;
+  private final String micaVariableReference;
+
+  public RQLFieldReferences(String micaVariableReference, Dataset dataset, BaseStudyTable studyTable, BaseStudy study,
+                            DatasetVariable variable) {
+    this.dataset = dataset;
+    this.studyTable = studyTable;
+    this.study = study;
+    this.variable = variable;
+    this.micaVariableReference = micaVariableReference;
+  }
+
+  public DatasetVariable getVariable() {
+    return variable;
+  }
+
+  public Dataset getDataset() {
+    return dataset;
+  }
+
+  public BaseStudy getStudy() {
+    return study;
+  }
+
+  public String getOpal() {
+    return Strings.isNullOrEmpty(study.getOpal()) ? "_default" : study.getOpal();
+  }
+
+  public String getTableReference() {
+    return studyTable.getProject() + "." + studyTable.getTable();
+  }
+
+  public String getOpalVariableReference() {
+    return getTableReference() + ":" + variable.getName();
+  }
+
+  public String getMicaVariableReference() {
+    return micaVariableReference;
+  }
+}

--- a/mica-search/src/main/java/org/obiba/mica/dataset/search/rest/AbstractPublishedDatasetResource.java
+++ b/mica-search/src/main/java/org/obiba/mica/dataset/search/rest/AbstractPublishedDatasetResource.java
@@ -142,7 +142,7 @@ public abstract class AbstractPublishedDatasetResource<T extends Dataset> {
     Mica.DatasetVariableHarmonizationDto.Builder builder = Mica.DatasetVariableHarmonizationDto.newBuilder();
     builder.setResolver(dtos.asDto(variableResolver));
 
-    dataset.getAllOpalTables().forEach(table -> {
+    dataset.getBaseStudyTables().forEach(table -> {
       try {
         builder.addDatasetVariableSummaries(
             getDatasetVariableSummaryDto(dataset.getId(), variableResolver.getName(), DatasetVariable.Type.Harmonized,

--- a/mica-search/src/main/java/org/obiba/mica/dataset/search/rest/harmonization/CsvHarmonizationVariablesWriter.java
+++ b/mica-search/src/main/java/org/obiba/mica/dataset/search/rest/harmonization/CsvHarmonizationVariablesWriter.java
@@ -58,7 +58,7 @@ public class CsvHarmonizationVariablesWriter {
   }
 
   private void writeHeader(CSVWriter writer, HarmonizationDataset dataset, String locale) {
-    List<String> headers = Lists.newArrayList(dataset.getAllOpalTables()).stream()
+    List<String> headers = Lists.newArrayList(dataset.getBaseStudyTables()).stream()
         .map(table -> {
           LocalizedString name = table.getName();
           String id = table instanceof StudyTable ? ((StudyTable)table).getStudyId() : ((HarmonizationStudyTable) table).getStudyId();
@@ -77,7 +77,7 @@ public class CsvHarmonizationVariablesWriter {
     harmonizationVariables.getVariableHarmonizationsList().forEach(
         variableHarmonization -> {
           List<String> row = Lists.newArrayList();
-          dataset.getAllOpalTables().forEach(
+          dataset.getBaseStudyTables().forEach(
             table -> {
               final boolean[] found = { false };
               variableHarmonization.getDatasetVariableSummariesList().forEach(

--- a/mica-search/src/main/java/org/obiba/mica/dataset/search/rest/harmonization/PublishedDataschemaDatasetVariableResource.java
+++ b/mica-search/src/main/java/org/obiba/mica/dataset/search/rest/harmonization/PublishedDataschemaDatasetVariableResource.java
@@ -86,9 +86,9 @@ public class PublishedDataschemaDatasetVariableResource extends AbstractPublishe
   public List<Math.SummaryStatisticsDto> getVariableSummaries() {
     ImmutableList.Builder<Math.SummaryStatisticsDto> builder = ImmutableList.builder();
     HarmonizationDataset dataset = getDataset(HarmonizationDataset.class, datasetId);
-    dataset.getAllOpalTables().forEach(table -> {
+    dataset.getBaseStudyTables().forEach(table -> {
       try {
-        String studyId = ((BaseStudyTable)table).getStudyId();
+        String studyId = table.getStudyId();
         builder.add(datasetService
           .getVariableSummary(dataset, variableName, studyId, table.getProject(), table.getTable())
           .getWrappedDto());
@@ -106,9 +106,9 @@ public class PublishedDataschemaDatasetVariableResource extends AbstractPublishe
   public List<Search.QueryResultDto> getVariableFacets() {
     ImmutableList.Builder<Search.QueryResultDto> builder = ImmutableList.builder();
     HarmonizationDataset dataset = getDataset(HarmonizationDataset.class, datasetId);
-    dataset.getAllOpalTables().forEach(table -> {
+    dataset.getBaseStudyTables().forEach(table -> {
       try {
-        String studyId = ((BaseStudyTable)table).getStudyId();
+        String studyId = table.getStudyId();
         builder.add(datasetService
           .getVariableFacet(dataset, variableName, studyId, table.getProject(), table.getTable()));
       } catch(NoSuchVariableException | NoSuchValueTableException e) {
@@ -128,10 +128,10 @@ public class PublishedDataschemaDatasetVariableResource extends AbstractPublishe
     Mica.DatasetVariableAggregationsDto.Builder aggDto = Mica.DatasetVariableAggregationsDto.newBuilder();
 
     List<Future<Math.SummaryStatisticsDto>> results = Lists.newArrayList();
-    dataset.getAllOpalTables().forEach(table -> results.add(helper.getVariableFacet(dataset, variableName, table)));
+    dataset.getBaseStudyTables().forEach(table -> results.add(helper.getVariableFacet(dataset, variableName, table)));
 
-    for(int i = 0; i < dataset.getAllOpalTables().size(); i++) {
-      OpalTable opalTable = dataset.getAllOpalTables().get(i);
+    for(int i = 0; i < dataset.getBaseStudyTables().size(); i++) {
+      BaseStudyTable opalTable = dataset.getBaseStudyTables().get(i);
       Future<Math.SummaryStatisticsDto> futureResult = results.get(i);
       try {
         builder.add(dtos.asDto(opalTable, futureResult.get()).build());
@@ -168,12 +168,12 @@ public class PublishedDataschemaDatasetVariableResource extends AbstractPublishe
     Mica.DatasetVariableContingenciesDto.Builder crossDto = Mica.DatasetVariableContingenciesDto.newBuilder();
 
     List<Future<Search.QueryResultDto>> results = Lists.newArrayList();
-    dataset.getAllOpalTables().forEach(table -> results.add(helper.getContingencyTable(dataset, var, crossVar, table)));
+    dataset.getBaseStudyTables().forEach(table -> results.add(helper.getContingencyTable(dataset, var, crossVar, table)));
 
     Multimap<String, Mica.DatasetVariableAggregationDto> termAggregations = LinkedListMultimap.create();
 
-    for(int i = 0; i < dataset.getAllOpalTables().size(); i++) {
-      OpalTable opalTable = dataset.getAllOpalTables().get(i);
+    for(int i = 0; i < dataset.getBaseStudyTables().size(); i++) {
+      BaseStudyTable opalTable = dataset.getBaseStudyTables().get(i);
       Future<Search.QueryResultDto> futureResult = results.get(i);
 
       try {

--- a/mica-search/src/main/java/org/obiba/mica/dataset/search/rest/harmonization/PublishedHarmonizedDatasetVariableResource.java
+++ b/mica-search/src/main/java/org/obiba/mica/dataset/search/rest/harmonization/PublishedHarmonizedDatasetVariableResource.java
@@ -26,7 +26,7 @@ import com.google.common.base.Strings;
 import org.apache.commons.math3.util.Pair;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.obiba.magma.NoSuchValueTableException;
-import org.obiba.mica.core.domain.OpalTable;
+import org.obiba.mica.core.domain.BaseStudyTable;
 import org.obiba.mica.dataset.DatasetVariableResource;
 import org.obiba.mica.dataset.domain.DatasetVariable;
 import org.obiba.mica.dataset.domain.HarmonizationDataset;
@@ -94,9 +94,8 @@ public class PublishedHarmonizedDatasetVariableResource extends AbstractPublishe
   @Timed
   public Mica.DatasetVariableAggregationDto getVariableAggregations() {
     HarmonizationDataset dataset = getDataset(HarmonizationDataset.class, datasetId);
-    for(OpalTable opalTable : dataset.getAllOpalTables()) {
+    for(BaseStudyTable opalTable : dataset.getBaseStudyTables()) {
       String opalTableId = studyId;
-
       if(opalTable.isFor(opalTableId, project, table)) {
         try {
           return dtos.asDto(opalTable,
@@ -123,9 +122,8 @@ public class PublishedHarmonizedDatasetVariableResource extends AbstractPublishe
   private Mica.DatasetVariableContingencyDto getContingencyDto(DatasetVariable var, DatasetVariable crossVar) {
     HarmonizationDataset dataset = getDataset(HarmonizationDataset.class, datasetId);
 
-    for(OpalTable opalTable : dataset.getAllOpalTables()) {
+    for(BaseStudyTable opalTable : dataset.getBaseStudyTables()) {
       String opalTableId = studyId;
-
       if(opalTable.isFor(opalTableId, project, table)) {
         try {
           return dtos.asContingencyDto(opalTable, var, crossVar,

--- a/mica-web-model/src/main/protobuf/MicaSearch.proto
+++ b/mica-web-model/src/main/protobuf/MicaSearch.proto
@@ -206,3 +206,18 @@ message BucketsCoverageDto {
   repeated RowDto rows = 4;
 }
 
+message DatasetEntitiesCountDto {
+  required string query = 1;
+  required int32 count = 2;
+  required DocumentDigestDto variable = 3;
+  required DocumentDigestDto dataset = 4;
+  required DocumentDigestDto study = 5;
+  repeated DatasetEntitiesCountDto counts = 6;
+}
+
+message EntitiesCountDto {
+  required string entityType = 1;
+  required string query = 2;
+  required int32 total = 3;
+  repeated DatasetEntitiesCountDto counts = 4;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <metrics-spring.version>3.0.0</metrics-spring.version>
     <nosqlunit.version>0.7.9</nosqlunit.version>
     <obiba-commons.version>1.9.3</obiba-commons.version>
-    <opal.version>2.9.6</opal.version>
+    <opal.version>2.11-SNAPSHOT</opal.version>
     <opencsv.version>2.3</opencsv.version>
     <poi.version>3.9</poi.version>
     <protobuf.version>2.5.0</protobuf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <metrics-spring.version>3.0.0</metrics-spring.version>
     <nosqlunit.version>0.7.9</nosqlunit.version>
     <obiba-commons.version>1.9.3</obiba-commons.version>
-    <opal.version>2.11-SNAPSHOT</opal.version>
+    <opal.version>2.10.2</opal.version>
     <opencsv.version>2.3</opencsv.version>
     <poi.version>3.9</poi.version>
     <protobuf.version>2.5.0</protobuf.version>


### PR DESCRIPTION
This is a web service only and does not interfere with any of the other mica 3.1 features.
Example of query on command line: 

`mica rest -u administrator -p password -m GET "/datasets/entities/_count?query=range(fnac:PITUUS:Collected,(1.5,*)),in(fnac:SUKUP:Collected,(1))"`