### PR TITLE
rql download in steps

### DIFF
--- a/mica-rest/src/main/java/org/obiba/mica/access/rest/CsvHistoryReportGenerator.java
+++ b/mica-rest/src/main/java/org/obiba/mica/access/rest/CsvHistoryReportGenerator.java
@@ -45,13 +45,18 @@ public class CsvHistoryReportGenerator implements CsvReportGenerator {
   }
 
   @Override
-  public void write(OutputStream outputStream) {
+  public void write(OutputStream outputStream, boolean omitHeader) {
     try (CSVWriter writer = new CSVWriter(new PrintWriter(outputStream))) {
-      writeHeader(writer);
+      if (!omitHeader) writeHeader(writer);
       writeBody(writer);
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
+  }
+
+  @Override
+  public void write(OutputStream outputStream) {
+    write(outputStream, false);
   }
 
   private String[] toArray(String... elements) {

--- a/mica-search/src/main/java/org/obiba/mica/search/csvexport/CsvReportGenerator.java
+++ b/mica-search/src/main/java/org/obiba/mica/search/csvexport/CsvReportGenerator.java
@@ -14,6 +14,8 @@ import java.io.OutputStream;
 
 public interface CsvReportGenerator {
 
+  void write(OutputStream outputStream, boolean omitHeader);
+
   void write(OutputStream outputStream);
 
 }

--- a/mica-search/src/main/java/org/obiba/mica/search/csvexport/generators/CsvReportGeneratorImpl.java
+++ b/mica-search/src/main/java/org/obiba/mica/search/csvexport/generators/CsvReportGeneratorImpl.java
@@ -26,9 +26,9 @@ public abstract class CsvReportGeneratorImpl implements CsvReportGenerator {
 
   private static final Logger log = LoggerFactory.getLogger(CsvReportGeneratorImpl.class);
 
-  public void write(OutputStream outputStream) {
+  public void write(OutputStream outputStream, boolean omitHeader) {
     try (CSVWriter writer = new CSVWriter(new PrintWriter(new OutputStreamWriter(outputStream, "UTF-8")))) {
-      writeHeader(writer);
+      if (!omitHeader) writeHeader(writer);
       writeEachLine(writer);
       outputStream.flush();
     } catch (IOException e) {
@@ -37,6 +37,10 @@ public abstract class CsvReportGeneratorImpl implements CsvReportGenerator {
     } catch (Exception e) {
       log.error("CSV report extraction failed", e);
     }
+  }
+
+  public void write(OutputStream outputStream) {
+    write(outputStream, false);
   }
 
   protected abstract void writeHeader(CSVWriter writer);


### PR DESCRIPTION
Will download csv in steps where steps will be dictated by client.
For now, standard csv download limits are hard-coded to a limit of 100000 except for carts where the limit is the configured "max items per set".