### PR TITLE
Feature/opal view from mica variable set

### DIFF
--- a/mica-core/pom.xml
+++ b/mica-core/pom.xml
@@ -64,6 +64,10 @@
       <artifactId>metrics-servlets</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.googlecode.protobuf-java-format</groupId>
+      <artifactId>protobuf-java-format</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-json-org</artifactId>
     </dependency>

--- a/mica-core/src/main/java/org/obiba/mica/dataset/service/VariableSetService.java
+++ b/mica-core/src/main/java/org/obiba/mica/dataset/service/VariableSetService.java
@@ -10,17 +10,32 @@
 
 package org.obiba.mica.dataset.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitable;
 import com.google.common.collect.Lists;
+import com.googlecode.protobuf.format.JsonFormat;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.obiba.mica.core.domain.Attributes;
 import org.obiba.mica.core.domain.DocumentSet;
+import org.obiba.mica.core.domain.LocalizedString;
 import org.obiba.mica.core.domain.OpalTable;
 import org.obiba.mica.core.service.DocumentSetService;
 import org.obiba.mica.dataset.domain.Dataset;
+import org.obiba.mica.dataset.domain.DatasetCategory;
 import org.obiba.mica.dataset.domain.DatasetVariable;
 import org.obiba.mica.dataset.domain.HarmonizationDataset;
 import org.obiba.mica.dataset.domain.StudyDataset;
 import org.obiba.mica.study.service.PublishedDatasetVariableService;
+import org.obiba.mica.study.service.PublishedStudyService;
+import org.obiba.opal.web.model.Magma;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
@@ -37,12 +52,21 @@ public class VariableSetService extends DocumentSetService {
 
   private final PublishedDatasetService publishedDatasetService;
 
+  private final PublishedStudyService publishedStudyService;
+
+  private final ObjectMapper mapper;
+
   @Inject
   public VariableSetService(
     PublishedDatasetVariableService publishedDatasetVariableService,
-    PublishedDatasetService publishedDatasetService) {
+    PublishedDatasetService publishedDatasetService,
+    PublishedStudyService publishedStudyService) {
     this.publishedDatasetVariableService = publishedDatasetVariableService;
     this.publishedDatasetService = publishedDatasetService;
+    this.publishedStudyService = publishedStudyService;
+
+    mapper = new ObjectMapper();
+    mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
   }
 
   @Override
@@ -121,22 +145,109 @@ public class VariableSetService extends DocumentSetService {
     return publishedDatasetVariableService.findByIds(ids.subList(from, to));
   }
 
-  public List<String> toOpalVariableFullNames(String variableSetId) {
-    DocumentSet documentSet = get(variableSetId);
+  public List<Magma.ViewDto> createOpalViews(DocumentSet documentSet) {
+    List<Magma.ViewDto> views = new ArrayList<>();
+
     List<DatasetVariable> variables = publishedDatasetVariableService.findByIds(Lists.newArrayList(documentSet.getIdentifiers()));
 
-    Map<String, String> opalTableFullNameMap = publishedDatasetService.findByIds(variables.stream()
+    List<Dataset> datasets = publishedDatasetService.findByIds(variables.stream()
       .map(DatasetVariable::getDatasetId)
       .distinct()
       .collect(Collectors.toList())
-    ).stream()
-      .collect(Collectors.toMap(Dataset::getId, this::toOpalTableFullName));
+    );
 
-    return variables.stream()
+    Map<String, String> opalTableFullNameMap = datasets.stream().collect(Collectors.toMap(Dataset::getId, this::toOpalTableFullName));
+
+    List<Magma.VariableDto> variableDtos = variables.stream()
       .filter(variable -> opalTableFullNameMap.containsKey(variable.getDatasetId()))
-      .map(variable -> opalTableFullNameMap.get(variable.getDatasetId()) + ":" + variable.getName())
+      .map(variable -> toMagmaVariable(variable, opalTableFullNameMap))
       .collect(Collectors.toList());
+
+    Magma.ViewDto.Builder builder = Magma.ViewDto.newBuilder();
+    builder.setExtension(Magma.VariableListViewDto.view, Magma.VariableListViewDto.newBuilder().addAllVariables(variableDtos).build());
+
+    builder.addAllFrom(opalTableFullNameMap.values());
+    builder.setName("view-" + new Date().getTime());
+
+    views.add(builder.build());
+
+    return views;
   }
+
+  private Magma.VariableDto toMagmaVariable(DatasetVariable datasetVariable, Map<String, String> opalTableFullNameMap) {
+    Magma.VariableDto.Builder builder = Magma.VariableDto.newBuilder();
+
+    builder.setName(datasetVariable.getName());
+    builder.setIndex(datasetVariable.getIndex());
+    builder.setReferencedEntityType(datasetVariable.getReferencedEntityType());
+    builder.setUnit(datasetVariable.getUnit());
+    builder.setMimeType(datasetVariable.getMimeType());
+    builder.setIsRepeatable(datasetVariable.isRepeatable());
+    builder.setOccurrenceGroup(datasetVariable.getOccurrenceGroup());
+    builder.setValueType(datasetVariable.getValueType());
+    builder.setEntityType(datasetVariable.getEntityType());
+
+    if (datasetVariable.hasAttributes()) {
+      builder.addAllAttributes(toAttributeDtoList(datasetVariable.getAttributes()));
+    }
+
+    if (datasetVariable.hasCategories()) {
+      builder.addAllCategories(toCategoryDtoList(datasetVariable.getCategories()));
+    }
+
+    String tableFullName = opalTableFullNameMap.get(datasetVariable.getDatasetId());
+    String[] split = tableFullName.split("\\.");
+    builder.addAttributes(Magma.AttributeDto.newBuilder().setName("derivedFrom").setNamespace("opal").setValue("/datasource/" + split[0] + "/table/" + split[1] + "/variable/" + datasetVariable.getName()).build());
+    builder.addAttributes(Magma.AttributeDto.newBuilder().setName("script").setValue("$('" + datasetVariable.getName() + "')").build());
+
+    return builder.build();
+  }
+
+  private List<Magma.AttributeDto> toAttributeDtoList(Attributes attributes) {
+    return attributes.asAttributeList().stream().map(attribute -> {
+      Magma.AttributeDto.Builder builder = Magma.AttributeDto.newBuilder();
+
+      builder.setName(attribute.getName());
+
+      if (attribute.hasNamespace()) builder.setNamespace(attribute.getNamespace());
+
+      LocalizedString values = attribute.getValues();
+      String firstKey = values.firstKey();
+
+      if (!"und".equals(firstKey)) builder.setLocale(firstKey);
+
+      builder.setValue(values.get(firstKey));
+
+      return builder.build();
+    }).collect(Collectors.toList());
+  }
+
+
+  private List<Magma.CategoryDto> toCategoryDtoList(List<DatasetCategory> categories) {
+    return categories.stream().map(category -> {
+      Magma.CategoryDto.Builder builder = Magma.CategoryDto.newBuilder();
+
+      builder.setName(category.getName());
+      builder.setIsMissing(category.isMissing());
+
+      Attributes categoryAttributes = category.getAttributes();
+      if (categoryAttributes != null && !categoryAttributes.isEmpty()) builder.addAllAttributes(
+        toAttributeDtoList(categoryAttributes));
+
+      return builder.build();
+    }).collect(Collectors.toList());
+  }
+
+  public void createZip(List<Magma.ViewDto> views, OutputStream outputStream) throws IOException {
+    try (ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream)) {
+      for (Magma.ViewDto view : views) {
+        zipOutputStream.putNextEntry(new ZipEntry(view.getName()));
+        zipOutputStream.write(JsonFormat.printToString(view).getBytes());
+        zipOutputStream.closeEntry();
+      }
+    }
+  }
+
   private String toOpalTableFullName(Dataset dataset) {
     OpalTable opalTable = dataset instanceof StudyDataset ? ((StudyDataset) dataset).getSafeStudyTable() : ((HarmonizationDataset) dataset).getSafeHarmonizationTable();
     return opalTable.getProject() + "." + opalTable.getTable();

--- a/mica-core/src/main/java/org/obiba/mica/dataset/service/VariableSetService.java
+++ b/mica-core/src/main/java/org/obiba/mica/dataset/service/VariableSetService.java
@@ -182,7 +182,7 @@ public class VariableSetService extends DocumentSetService {
       builder.setExtension(Magma.VariableListViewDto.view, Magma.VariableListViewDto.newBuilder().addAllVariables(value).build());
 
       builder.addAllFrom(usedEntityTypeProjectFullnameMap.get(key));
-      builder.setName(usedEntityTypeProjectFullnameMap.get(key).toArray()[0].toString().split("\\.")[0] + "-view-" + new Date().getTime());
+      builder.setName(usedEntityTypeProjectFullnameMap.get(key).toArray()[0].toString().split("\\.")[0] + "-view-" + key + "-" + new Date().getTime());
 
       views.add(builder.build());
     });

--- a/mica-core/src/main/java/org/obiba/mica/dataset/service/VariableSetService.java
+++ b/mica-core/src/main/java/org/obiba/mica/dataset/service/VariableSetService.java
@@ -137,12 +137,31 @@ public class VariableSetService extends DocumentSetService {
   }
 
   /**
+   * Zip View dtos
+   *
+   * @param documentSet a set of variables, source for opal views
+   * @param outputStream the outputstream
+   * @throws IOException in case the zip fails
+   */
+  public void createOpalViewsZip(DocumentSet documentSet, OutputStream outputStream) throws IOException {
+    List<Magma.ViewDto> views = createOpalViews(documentSet);
+
+    try (ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream)) {
+      for (Magma.ViewDto view : views) {
+        zipOutputStream.putNextEntry(new ZipEntry(view.getName() + ".json"));
+        zipOutputStream.write(JsonFormat.printToString(view).getBytes());
+        zipOutputStream.closeEntry();
+      }
+    }
+  }
+
+  /**
    * Get a list of opal view dto for backup restore purposes
    *
    * @param documentSet The source variable document set
    * @return a list of opal views grouped by project and entity type
    */
-  public List<Magma.ViewDto> createOpalViews(DocumentSet documentSet) {
+  private List<Magma.ViewDto> createOpalViews(DocumentSet documentSet) {
     List<Magma.ViewDto> views = new ArrayList<>();
 
     List<DatasetVariable> variables = publishedDatasetVariableService.findByIds(Lists.newArrayList(documentSet.getIdentifiers()));
@@ -163,23 +182,6 @@ public class VariableSetService extends DocumentSetService {
     }
 
     return views;
-  }
-
-  /**
-   * Zip View dtos
-   *
-   * @param views a list of opal views
-   * @param outputStream the outputstream
-   * @throws IOException in case the zip fails
-   */
-  public void createZip(List<Magma.ViewDto> views, OutputStream outputStream) throws IOException {
-    try (ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream)) {
-      for (Magma.ViewDto view : views) {
-        zipOutputStream.putNextEntry(new ZipEntry(view.getName() + ".json"));
-        zipOutputStream.write(JsonFormat.printToString(view).getBytes());
-        zipOutputStream.closeEntry();
-      }
-    }
   }
 
   private List<Magma.ViewDto> createViewsDto(List<DatasetVariable> variables, Map<String, String> opalTableFullNameMap) {

--- a/mica-core/src/main/java/org/obiba/mica/dataset/service/VariableSetService.java
+++ b/mica-core/src/main/java/org/obiba/mica/dataset/service/VariableSetService.java
@@ -136,6 +136,12 @@ public class VariableSetService extends DocumentSetService {
     return publishedDatasetVariableService.findByIds(ids.subList(from, to));
   }
 
+  /**
+   * Get a list of opal view dto for backup restore purposes
+   *
+   * @param documentSet The source variable document set
+   * @return a list of opal views grouped by project and entity type
+   */
   public List<Magma.ViewDto> createOpalViews(DocumentSet documentSet) {
     List<Magma.ViewDto> views = new ArrayList<>();
 
@@ -157,6 +163,23 @@ public class VariableSetService extends DocumentSetService {
     }
 
     return views;
+  }
+
+  /**
+   * Zip View dtos
+   *
+   * @param views a list of opal views
+   * @param outputStream the outputstream
+   * @throws IOException in case the zip fails
+   */
+  public void createZip(List<Magma.ViewDto> views, OutputStream outputStream) throws IOException {
+    try (ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream)) {
+      for (Magma.ViewDto view : views) {
+        zipOutputStream.putNextEntry(new ZipEntry(view.getName() + ".json"));
+        zipOutputStream.write(JsonFormat.printToString(view).getBytes());
+        zipOutputStream.closeEntry();
+      }
+    }
   }
 
   private List<Magma.ViewDto> createViewsDto(List<DatasetVariable> variables, Map<String, String> opalTableFullNameMap) {
@@ -252,16 +275,6 @@ public class VariableSetService extends DocumentSetService {
 
       return builder.build();
     }).collect(Collectors.toList());
-  }
-
-  public void createZip(List<Magma.ViewDto> views, OutputStream outputStream) throws IOException {
-    try (ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream)) {
-      for (Magma.ViewDto view : views) {
-        zipOutputStream.putNextEntry(new ZipEntry(view.getName() + ".json"));
-        zipOutputStream.write(JsonFormat.printToString(view).getBytes());
-        zipOutputStream.closeEntry();
-      }
-    }
   }
 
   private String toOpalTableFullName(Dataset dataset) {

--- a/mica-core/src/main/java/org/obiba/mica/web/model/MicaConfigDtos.java
+++ b/mica-core/src/main/java/org/obiba/mica/web/model/MicaConfigDtos.java
@@ -151,6 +151,8 @@ class MicaConfigDtos {
       builder.setCurrentUserCanCreateSets(true);
     }
 
+    builder.setDownloadOpalViewsFromSetsAllowed(subjectAclService.isPermitted("/set/documents", "VIEW", "_opal"));
+
     return builder.build();
   }
 

--- a/mica-rest/src/main/java/org/obiba/mica/access/rest/DataAccessRequestsResource.java
+++ b/mica-rest/src/main/java/org/obiba/mica/access/rest/DataAccessRequestsResource.java
@@ -32,7 +32,6 @@ import org.obiba.mica.security.service.SubjectAclService;
 import org.obiba.mica.user.UserProfileService;
 import org.obiba.mica.web.model.Dtos;
 import org.obiba.mica.web.model.Mica;
-import org.obiba.shiro.realm.ObibaRealm.Subject;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 

--- a/mica-rest/src/main/java/org/obiba/mica/micaConfig/rest/MicaConfigResource.java
+++ b/mica-rest/src/main/java/org/obiba/mica/micaConfig/rest/MicaConfigResource.java
@@ -65,6 +65,7 @@ import org.obiba.mica.network.domain.Network;
 import org.obiba.mica.network.event.IndexNetworksEvent;
 import org.obiba.mica.project.domain.Project;
 import org.obiba.mica.security.Roles;
+import org.obiba.mica.security.rest.SubjectAclResource;
 import org.obiba.mica.study.domain.HarmonizationStudy;
 import org.obiba.mica.study.domain.Study;
 import org.obiba.mica.study.event.IndexStudiesEvent;
@@ -242,6 +243,12 @@ public class MicaConfigResource {
     }
 
     return Response.status(Response.Status.NOT_FOUND).build();
+  }
+  @Path("/document-sets/permissions")
+  public SubjectAclResource documentSetsResource() {
+    SubjectAclResource subjectAclResource = applicationContext.getBean(SubjectAclResource.class);
+    subjectAclResource.setResourceInstance("/set/documents", "_opal");
+    return subjectAclResource;
   }
 
   @GET

--- a/mica-search/src/main/java/org/obiba/mica/variable/search/rest/PublishedDatasetVariablesSetResource.java
+++ b/mica-search/src/main/java/org/obiba/mica/variable/search/rest/PublishedDatasetVariablesSetResource.java
@@ -16,6 +16,7 @@ import java.io.BufferedOutputStream;
 import java.util.Collection;
 import org.apache.shiro.authz.AuthorizationException;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.obiba.mica.core.domain.DocumentSet;
 import org.obiba.mica.dataset.service.VariableSetService;
 import org.obiba.mica.micaConfig.domain.MicaConfig;
@@ -27,7 +28,6 @@ import org.obiba.mica.spi.search.Searcher;
 import org.obiba.mica.web.model.Dtos;
 import org.obiba.mica.web.model.Mica;
 import org.obiba.mica.web.model.MicaSearch;
-import org.obiba.opal.web.model.Magma;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
@@ -114,6 +114,7 @@ public class PublishedDatasetVariablesSetResource {
   @Path("/documents/_opal")
   @Produces(MediaType.APPLICATION_OCTET_STREAM)
   public Response createOpalViews(@PathParam("id") String id) {
+    subjectAclService.checkPermission("/set/documents", "VIEW", "_opal");
     DocumentSet set = getSecuredDocumentSet(id);
     StreamingOutput streamingOutput = stream -> variableSetService.createOpalViewsZip(set, new BufferedOutputStream(stream));
 

--- a/mica-search/src/main/java/org/obiba/mica/variable/search/rest/PublishedDatasetVariablesSetResource.java
+++ b/mica-search/src/main/java/org/obiba/mica/variable/search/rest/PublishedDatasetVariablesSetResource.java
@@ -111,12 +111,11 @@ public class PublishedDatasetVariablesSetResource {
   }
 
   @GET
-  @Path("/opal/_export")
+  @Path("/documents/_opal")
   @Produces(MediaType.APPLICATION_OCTET_STREAM)
-  public Response createView(@PathParam("id") String id) {
+  public Response createOpalViews(@PathParam("id") String id) {
     DocumentSet set = getSecuredDocumentSet(id);
-    List<Magma.ViewDto> views = variableSetService.createOpalViews(set);
-    StreamingOutput streamingOutput = stream -> variableSetService.createZip(views, new BufferedOutputStream(stream));
+    StreamingOutput streamingOutput = stream -> variableSetService.createOpalViewsZip(set, new BufferedOutputStream(stream));
 
     return Response.ok(streamingOutput, MediaType.APPLICATION_OCTET_STREAM).header("Content-Disposition", "attachment; filename=\"opal-views-" + id + ".zip\"").build();
   }

--- a/mica-web-model/src/main/protobuf/Mica.proto
+++ b/mica-web-model/src/main/protobuf/Mica.proto
@@ -428,6 +428,7 @@ message MicaConfigDto {
   optional int32 setTimeToLive = 41;
   required bool isSetsAnalysisEnabled = 42;
   required bool isSetsSearchEnabled = 43;
+  required bool downloadOpalViewsFromSetsAllowed = 44 [default = false];
 }
 
 message PublicMicaConfigDto {

--- a/mica-webapp/src/main/resources/i18n/en.json
+++ b/mica-webapp/src/main/resources/i18n/en.json
@@ -312,6 +312,8 @@
     "max-number-sets-help": "Maximum number of lists that a user can create.",
     "max-items-per-set": "Maximum number of documents",
     "max-items-per-set-help": "Maximum number of documents a list or the cart can contain.",
+    "opal-sets-views-download-permission": "Allow opal view creation from a list.",
+    "opal-sets-views-download-permission-help": "Manage Opal views download from lists permissions. These views can then be imported to Opal",
     "short-title": "Configuration",
     "title": "General Configuration",
     "title-edit": "Edit General Configuration",
@@ -1049,6 +1051,8 @@
       "no-variable-added": "No variable has been added to the {{arg0}} list.",
       "variables-added": "<a href='{{arg0}}?id={{arg1}}' target='_self'><u>{{arg2}} variable(s) were added to list {{arg3}}.</u></a>"
     },
+    "opal-views-download-button-text": "Opal Views",
+    "opal-views-download-button-help": "Download opal views representation of this list.",
     "add": {
       "button": {
         "cart-label": "Add to Cart",

--- a/mica-webapp/src/main/resources/i18n/fr.json
+++ b/mica-webapp/src/main/resources/i18n/fr.json
@@ -312,6 +312,8 @@
     "max-number-sets-help": "Le nombre maximum de listes qu'un utilisateur peut créer.",
     "max-items-per-set": "Nombre maximum de documents",
     "max-items-per-set-help": "Le nombre maximum de documents qu'une liste ou le panier peut contenir.",
+    "opal-sets-views-download-permission": "Autoriser la création de vues d'opal à partir d'une liste.",
+    "opal-sets-views-download-permission-help": "Permissions gérant le téléchargement de vues opal à partir de listes. Ces vues pouront être ensuite importer dans Opal",
     "short-title": "Configuration",
     "title": "Configuration générale",
     "title-edit": "Éditer la configuration générale",
@@ -1049,6 +1051,8 @@
       "no-variable-added": "Aucune variable n'a été ajoutée à la liste {{arg0}}.",
       "variables-added": "<a href='{{arg0}}?id={{arg1}}' target='_self'><u>{{arg2}} variable(s) ont été ajoutées à la liste {{arg3}}.</u></a>"
     },
+    "opal-views-download-button-text": "Vues opal",
+    "opal-views-download-button-help": "Télécharger des vues opal représentant les items de cette liste.",
     "add": {
       "button": {
         "cart-label": "Ajouter au panier",

--- a/mica-webapp/src/main/webapp/app/config/config-controller.js
+++ b/mica-webapp/src/main/webapp/app/config/config-controller.js
@@ -25,6 +25,7 @@ mica.config
     'KeyStoreResource',
     'FormServerValidation',
     'NOTIFICATION_EVENTS',
+    'DocumentSetsPermissionsResource',
 
     function ($rootScope,
               $scope,
@@ -39,7 +40,8 @@ mica.config
               OpalCredentialResource,
               KeyStoreResource,
               FormServerValidation,
-              NOTIFICATION_EVENTS) {
+              NOTIFICATION_EVENTS,
+              DocumentSetsPermissionsResource) {
       $scope.micaConfig = MicaConfigResource.get();
 
       function getAvailableLanguages() {
@@ -237,6 +239,26 @@ mica.config
           }, function () {
           });
       };
+
+      $scope.documentSetsAcls = [];
+
+      $scope.onAddDocumentSetsAcl = function (acl) {
+        return DocumentSetsPermissionsResource.save(acl);
+      };
+
+      $scope.onRemoveDocumentSetsAcl = function (acl) {
+        return DocumentSetsPermissionsResource.delete(acl);
+      };
+
+      $scope.onLoadDocumentSetsAcls = function () {
+        $scope.documentSetsAcls = DocumentSetsPermissionsResource.query();
+        return $scope.documentSetsAcls;
+      };
+
+      $scope.overriddenRoleHelpTexts = {
+        'READER': 'config.opal-sets-views-download-permission'
+      };
+
     }])
 
   .controller('ImportKeyPairModalController', ['$scope', '$location', '$uibModalInstance', 'isOpalCredential',

--- a/mica-webapp/src/main/webapp/app/config/config-service.js
+++ b/mica-webapp/src/main/webapp/app/config/config-service.js
@@ -57,6 +57,18 @@ mica.config
         'export': {method: 'GET', url: 'ws/config/i18n/custom/export'}
       }, {});
     }])
+  .factory('DocumentSetsPermissionsResource', ['$resource', function ($resource) {
+    return $resource('ws/config/document-sets/permissions', {}, {
+      'save': {
+        method: 'PUT',
+        params: {type: '@type', principal: '@principal', role: '@role', otherResources: '@otherResources'},
+        errorHandler: true
+      },
+      'delete': {method: 'DELETE', params: {type: '@type', principal: '@principal'}, errorHandler: true},
+      'get': {method: 'GET', isArray: true}
+    });
+  }])
+
   .factory('StyleEditorService', [
     function () {
       return {

--- a/mica-webapp/src/main/webapp/app/config/views/config-view.html
+++ b/mica-webapp/src/main/webapp/app/config/views/config-view.html
@@ -242,6 +242,17 @@
         </tbody>
       </table>
 
+      <div class="help-block">{{'config.opal-sets-views-download-permission-help' | translate}}</div>
+      <permission-config-table
+        overridden-role-help-texts="overriddenRoleHelpTexts"
+        name="'opal-views'"
+        allow-blocked-principals="true"
+        permissions="documentSetsAcls"
+        on-add="onAddDocumentSetsAcl"
+        on-delete="onRemoveDocumentSetsAcl"
+        on-load="onLoadDocumentSetsAcls">
+      </permission-config-table>
+
     </div>
   </div>
   <div class="row">

--- a/mica-webapp/src/main/webapp/app/permission/permission-config-modal-form.html
+++ b/mica-webapp/src/main/webapp/app/permission/permission-config-modal-form.html
@@ -36,7 +36,7 @@
             <input type="radio" name="role" value="{{role}}" ng-model="acl.role" required>
             <span>{{'permission.' + role.toLowerCase() | translate}}</span>
           </label>
-          <p class="help-block hoffset3">{{'permission.' + role.toLowerCase() + '-config-help' | translate:name}}</p>
+          <p class="help-block hoffset3">{{getRoleHelpText(role) | translate:name}}</p>
         </div>
       </div>
 

--- a/mica-webapp/src/main/webapp/app/permission/permission-directives.js
+++ b/mica-webapp/src/main/webapp/app/permission/permission-directives.js
@@ -43,7 +43,9 @@ mica.permission
       onDelete: '=',
       onLoad: '=',
       name: '=',
-      otherResources: '<'
+      otherResources: '<',
+      overriddenRoleHelpTexts: '<',
+      allowBlockedPrincipals: '<'
     },
     templateUrl: 'app/permission/permission-config-table-template.html',
     controller: 'PermissionsConfigController'
@@ -70,6 +72,12 @@ mica.permission
           },
           otherResources: function () {
             return $scope.otherResources;
+          },
+          allowBlockedPrincipals: function () {
+            return $scope.allowBlockedPrincipals;
+          },
+          overriddenRoleHelpTexts: function () {
+            return $scope.overriddenRoleHelpTexts;
           }
         }
       }).result.then(function(result) {
@@ -109,8 +117,8 @@ mica.permission
     $scope.onLoad();
   }])
 
-.controller('PermissionsConfigModalController', ['$scope', '$uibModalInstance', 'AlertService', 'ServerErrorUtils', '$filter', 'acl', 'onAdd', 'name', 'otherResources',
-  function ($scope, $uibModalInstance, AlertService, ServerErrorUtils, $filter, acl, onAdd, name, otherResources) {
+.controller('PermissionsConfigModalController', ['$scope', '$uibModalInstance', 'AlertService', 'ServerErrorUtils', '$filter', 'acl', 'onAdd', 'name', 'otherResources', 'allowBlockedPrincipals', 'overriddenRoleHelpTexts',
+  function ($scope, $uibModalInstance, AlertService, ServerErrorUtils, $filter, acl, onAdd, name, otherResources, allowBlockedPrincipals, overriddenRoleHelpTexts) {
     $scope.ROLES = ['READER'];
     $scope.TYPES = [
       {name: 'USER', label: $filter('translate')('permission.user')},
@@ -144,7 +152,7 @@ mica.permission
 
     $scope.save = function (form) {
       form.principal.$setValidity('reserved-groups', true);
-      if ('GROUP' === $scope.selectedType.name && BLOCKED_NAMES.indexOf(acl.principal) > -1) {
+      if (!allowBlockedPrincipals && 'GROUP' === $scope.selectedType.name && BLOCKED_NAMES.indexOf(acl.principal) > -1) {
         form.principal.$setValidity('reserved-groups', false);
         AlertService.alert({
           id: 'PermissionsConfigModalController',
@@ -171,6 +179,14 @@ mica.permission
       }
 
       form.saveAttempted = true;
+    };
+
+    $scope.getRoleHelpText = function(role) {
+      var text = 'permission.' + role.toLowerCase() + '-config-help';
+      if (overriddenRoleHelpTexts) {
+        text = overriddenRoleHelpTexts[role] || text;
+      }
+      return text;
     };
 
     $scope.cancel = function () {

--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,12 @@
       </dependency>
 
       <dependency>
+        <groupId>com.googlecode.protobuf-java-format</groupId>
+        <artifactId>protobuf-java-format</artifactId>
+        <version>1.2</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.glassfish.jersey</groupId>
         <artifactId>jersey-bom</artifactId>
         <version>${jersey.version}</version>


### PR DESCRIPTION
relates to #3627 

Decided to create view in mica, because oapl's search did not have all the information needed to create views.

Mica rest call would be: `variables/set/{set_id}/opal/_export`

Need more info with respect to permissions and use case.

Currently a user can create opal views from a variable set (be it named or not).
Views are zipped and downloaded immediately.
Views are not grouped by opal.

For now a user can only create a view from own variable set (there is no share set mechanism unless one makes use of the import/export rest resources).

Should there be a permission manager for who can use the download opal view feature?
Should opal python client support zips?