### PR TITLE
Optimize coverage queries by excluding extra aggregations.

### DIFF
--- a/mica-search/src/main/java/org/obiba/mica/search/queries/VariableQuery.java
+++ b/mica-search/src/main/java/org/obiba/mica/search/queries/VariableQuery.java
@@ -316,10 +316,12 @@ public class VariableQuery extends AbstractDocumentQuery {
       });
     }
 
-    // required for the counts to work
-    if (!properties.containsKey(JOIN_FIELD)) properties.put(JOIN_FIELD, "");
-    if (!properties.containsKey(DATASET_ID)) properties.put(DATASET_ID, "");
-    if (!properties.containsKey(SETS)) properties.put(SETS, "");
+    // required for the counts to work except when going coverage
+    if (QueryMode.COVERAGE != mode) {
+      if (!properties.containsKey(JOIN_FIELD)) properties.put(JOIN_FIELD, "");
+      if (!properties.containsKey(DATASET_ID)) properties.put(DATASET_ID, "");
+      if (!properties.containsKey(SETS)) properties.put(SETS, "");
+    }
 
     return properties;
   }


### PR DESCRIPTION
This optimization basically reduces the Elasticsearch response by ~50% resulting in a quicker client response time. The UI rendering lag remains the same and it will be part of a future fix.