### PR TITLE
Added table-responsive to DT dom setting.

### DIFF
--- a/mica-webapp/src/main/webapp/assets/js/mica-search.js
+++ b/mica-webapp/src/main/webapp/assets/js/mica-search.js
@@ -188,7 +188,7 @@ const DataTableDefaults = {
   ordering: false,
   lengthMenu: [10, 20, 50, 100],
   pageLength: 20,
-  dom: "<'row'<'col-sm-3'l><'col-sm-3'f><'col-sm-6'p>><'row'<'col-sm-12'tr>><'row'<'col-sm-5'i><'col-sm-7'p>>"
+  dom: "<'row'<'col-sm-3'l><'col-sm-3'f><'col-sm-6'p>><'row'<'table-responsive col-sm-12'tr>><'row'<'col-sm-5'i><'col-sm-7'p>>"
 };
 
 class StringLocalizer {


### PR DESCRIPTION
The `style="overflow-x: auto;` does not work 100%, the pager is always a little shifted to the left when scrolling is required. DataTable injects a parent `<div>` around `<table>` so the styling must be on this element as in PR.