### PR TITLE
Revert "Return algorithm value as LocalizedString"

### DIFF
--- a/mica-webapp/src/main/java/org/obiba/mica/web/controller/domain/Annotation.java
+++ b/mica-webapp/src/main/java/org/obiba/mica/web/controller/domain/Annotation.java
@@ -45,10 +45,6 @@ public class Annotation {
     return attribute.getValues().get("und");
   }
 
-  public LocalizedString getTermValues() {
-    return attribute.getValues();
-  }
-
   public LocalizedString getTermTitle() {
     Vocabulary vocabulary = getVocabulary();
     if (vocabulary.hasTerms() && vocabulary.hasTerm(getTermName())) {

--- a/mica-webapp/src/main/java/org/obiba/mica/web/controller/domain/HarmonizationAnnotations.java
+++ b/mica-webapp/src/main/java/org/obiba/mica/web/controller/domain/HarmonizationAnnotations.java
@@ -102,8 +102,8 @@ public class HarmonizationAnnotations {
     return algorithm.getVocabularyDescription();
   }
 
-  public LocalizedString getAlgorithmValue() {
-    return algorithm.getTermValues();
+  public String getAlgorithmValue() {
+    return algorithm.getTermName();
   }
 
   public boolean hasComment() {


### PR DESCRIPTION
Reverts obiba/mica2#4135

Because of this:

```
Caused by: freemarker.core.NonStringOrTemplateOutputException: For "${...}" content: Expected a string or something automatically convertible to string (number, date or boolean), or "template output" , but this has evaluated to an extended_hash (wrapper: f.t.SimpleHash):
==> harmoAnnotations.algorithmValue!""  [in template "variable.ftl" at line 248, column 65]

----
FTL stack trace ("~" means nesting-related):
	- Failed at: ${harmoAnnotations.algorithmValue!""}  [in template "variable.ftl" at line 248, column 63]
```