### PR TITLE
update mongo driver to 3.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <logback.version>1.2.3</logback.version>
     <logstash-logback.version>6.6</logstash-logback.version>
     <metrics-spring.version>3.0.0</metrics-spring.version>
-    <mongodb-driver.version>3.9.1</mongodb-driver.version>
+    <mongodb-driver.version>3.12.8</mongodb-driver.version>
     <nosqlunit.version>0.7.9</nosqlunit.version>
     <obiba-commons.version>1.15.2</obiba-commons.version>
     <opal.version>4.0.3</opal.version>


### PR DESCRIPTION
Relates to #4159 

According to https://docs.mongodb.com/drivers/java/, 3.12 supports mongo up to 4.4 (note that `The 3.12 driver does not support all MongoDB 4.4 features`).

Drivers over 4.0 will incur breaking changes in mica. While 3.12 will only mark methods as deprecated.

A future update to 4+ will still be best.