### PR TITLE
Bugfix/networkdto fields

### DIFF
--- a/mica-core/src/main/java/org/obiba/mica/web/model/NetworkDtos.java
+++ b/mica-core/src/main/java/org/obiba/mica/web/model/NetworkDtos.java
@@ -150,15 +150,18 @@ class NetworkDtos {
           || subjectAclService.isAccessible("/individual-study", sId))
         .collect(toList())), publishedStudyIds);
 
-    if(!publishedStudies.isEmpty() && !forListing) {
+    if(!publishedStudies.isEmpty()) {
       Map<String, Long> datasetVariableCounts = asDraft ? null :
         datasetVariableService.getCountByStudyIds(Lists.newArrayList(publishedStudyIds));
 
       publishedStudies.forEach(study -> {
         builder.addStudyIds(study.getId());
-        builder.addStudySummaries(
-          studySummaryDtos.asDtoBuilder(study, true,
-            datasetVariableCounts == null ? 0 : datasetVariableCounts.get(study.getId())));
+
+        if (!forListing) {
+          builder.addStudySummaries(
+            studySummaryDtos.asDtoBuilder(study, true,
+              datasetVariableCounts == null ? 0 : datasetVariableCounts.get(study.getId())));
+        }
       });
     }
 

--- a/mica-core/src/main/java/org/obiba/mica/web/model/NetworkDtos.java
+++ b/mica-core/src/main/java/org/obiba/mica/web/model/NetworkDtos.java
@@ -180,7 +180,7 @@ class NetworkDtos {
         || subjectAclService.isAccessible("/network", nId))
       .forEach(nId -> {
         try {
-          builder.addNetworkSummaries(networkSummaryDtos.asDtoBuilder(nId, asDraft));
+          if (!forListing) builder.addNetworkSummaries(networkSummaryDtos.asDtoBuilder(nId, asDraft));
           builder.addNetworkIds(nId);
         } catch(NoSuchEntityException e) {
           log.warn("Network not found in network {}: {}", network.getId(), nId);

--- a/mica-core/src/main/java/org/obiba/mica/web/model/NetworkDtos.java
+++ b/mica-core/src/main/java/org/obiba/mica/web/model/NetworkDtos.java
@@ -167,7 +167,7 @@ class NetworkDtos {
 
     unpublishedStudyIds.forEach(studyId -> {
       try {
-        builder.addStudySummaries(studySummaryDtos.asDto(studyId));
+        if (!forListing) builder.addStudySummaries(studySummaryDtos.asDto(studyId));
         builder.addStudyIds(studyId);
       } catch(NoSuchEntityException e) {
         log.warn("Study not found in network {}: {}", network.getId(), studyId);

--- a/mica-core/src/main/java/org/obiba/mica/web/model/NetworkDtos.java
+++ b/mica-core/src/main/java/org/obiba/mica/web/model/NetworkDtos.java
@@ -89,7 +89,7 @@ class NetworkDtos {
 
   @NotNull
   Mica.NetworkDto.Builder asDtoBuilder(@NotNull Network network, boolean asDraft) {
-    Mica.NetworkDto.Builder builder = asDtoBuilderInternal(network, asDraft);
+    Mica.NetworkDto.Builder builder = asDtoBuilderInternal(network, asDraft, false);
     List<String> roles = micaConfigService.getConfig().getRoles();
 
     if (network.getMembershipSortOrder() != null) {
@@ -111,10 +111,10 @@ class NetworkDtos {
 
   @NotNull
   Mica.NetworkDto.Builder asDtoBuilderForSearchListing(@NotNull Network network, boolean asDraft) {
-    return asDtoBuilderInternal(network, asDraft);
+    return asDtoBuilderInternal(network, asDraft, true);
   }
 
-  private Mica.NetworkDto.Builder asDtoBuilderInternal(@NotNull Network network, boolean asDraft) {
+  private Mica.NetworkDto.Builder asDtoBuilderInternal(@NotNull Network network, boolean asDraft, boolean forListing) {
     Mica.NetworkDto.Builder builder = Mica.NetworkDto.newBuilder();
 
     if(network.hasModel()) builder.setContent(JSONUtils.toJSON(network.getModel()));
@@ -150,7 +150,7 @@ class NetworkDtos {
           || subjectAclService.isAccessible("/individual-study", sId))
         .collect(toList())), publishedStudyIds);
 
-    if(!publishedStudies.isEmpty()) {
+    if(!publishedStudies.isEmpty() && !forListing) {
       Map<String, Long> datasetVariableCounts = asDraft ? null :
         datasetVariableService.getCountByStudyIds(Lists.newArrayList(publishedStudyIds));
 


### PR DESCRIPTION
relates to #4231 

`studyIds` and `networkIds` should appear in networkDto for listings.
Did not fill permission field if `asDraft` is false but kept `published` field for consistency (listing is not always just for published).
Did not keep study summaries if for listing.

Using the same query as in the related issue would give:
```
{
  "variableResultDto": { "totalHits": 4294, "totalCount": 18365 },
  "datasetResultDto": { "totalHits": 2, "totalCount": 33 },
  "studyResultDto": { "totalHits": 6, "totalCount": 18 },
  "networkResultDto": {
    "totalHits": 1,
    "totalCount": 7,
    "obiba.mica.NetworkResultDto.result": {
      "networks": [
        {
          "id": "cptp",
          "name": [
            {
              "lang": "en",
              "value": "Canadian Partnership for Tomorrow Project"
            }
          ],
          "acronym": [{ "lang": "en", "value": "CPTP" }],
          "description": [
            {
              "lang": "en",
              "value": "<p>The Canadian Partnership for Tomorrow Project (CPTP) will support novel, leading edge Canadian and international trans-disciplinary health and chronic disease research.  The CPTP is a consortium of five Canadian cohort studies.  It will be enriched over time with lifestyle, environmental, and phenotyping data, and biological samples, and will enable research into the causes of cancer and related chronic conditions in adults. The regional studies include: BC Generations Project, The Tomorrow Project (Alberta),  Ontario Health Study, CARTaGENE (Quebec) and the Atlantic Partnership for Tomorrow’s Health (PATH).<p>\r\n\r\n<strong> Objectives:</strong> The CPTP aims to investigate environmental, lifestyle and genetic factors related to the development of cancer and related chronic conditions. This cohort study will enrol Canadians between the ages of 35 and 69 years old from Alberta, British Columbia, New Brunswick, Newfoundland and Labrador, Nova Scotia, Prince Edward Island, Ontario and Quebec. A total of 180,000 participants with samples will be recruited. <p>\r\n\r\n<p><strong>Baseline recruitement:</strong> From 2009 to March 31, 2013*.<p>\r\n  *Passive recruitment may continue beyond March, 2013 via online tools. Collection of venous blood samples and phenotypes will continue to March, 2017. <p>\r\n\r\n<strong>Follow-up of participant:</strong> Starting in 2013, follow-up will continue indefinetely.\r\n\r\n<strong>Current number of participants:</strong> 257,759 (as of December 15, 2012)<p>\r\n\r\n<strong>Current number of participants with samples:</strong> 75,308 (as of December 15, 2012)<p>\r\n\r\n<p>As the project’s national funder, The Canadian Partnership Against Cancer is working in close collaboration with funding partners, sponsoring institutions, and leading Canadian and international scientific experts to deliver a legacy project for future generations.   The value of this rich resource will come from its utilization.  Soon, researchers will be able to access harmonized data and samples through a single point of access.  Over time, the CPTP will be expanded with data from this research, adding further breadth, depth and scientific value to the resource.  A specific enrichment initiative in cardiovascular disease will begin shortly.\r\n</p>"
            }
          ],
          "studyIds": ["cag", "atlantic-path", "ohs", "bcgp", "ttp", "cptp-hs"],
          "published": true,
          "logo": {
            "id": "cd3a5bfb-3778-43de-8aeb-e503d46931e6",
            "fileName": "spotlight-cptp.jpg",
            "type": "logo",
            "lang": "en",
            "size": 19627,
            "md5": "756066f9af96ada885877a415b02fa92",
            "timestamps": { "created": "2021-01-23T23:07:05.095Z" }
          },
          "content": "{\"maelstromAuthorization\":{\"authorizer\":null,\"authorized\":false},\"website\":\"http://www.partnershipfortomorrow.ca\"}",
          "obiba.mica.CountStatsDto.networkCountStats": {
            "variables": 4294,
            "studyDatasets": 1,
            "harmonizationDatasets": 1,
            "studies": 6,
            "individualStudies": 5,
            "harmonizationStudies": 1,
            "studyVariables": 3522,
            "dataschemaVariables": 772,
            "studiesWithVariables": 1,
            "harmonizationStudiesWithVariables": 1
          }
        }
      ]
    }
  }
}
```