### PR TITLE
remove MaxPermSize from defaults for deb and rpm since java 8 hs ignores…

### DIFF
--- a/mica-dist/src/main/deb/default/mica2
+++ b/mica-dist/src/main/deb/default/mica2
@@ -29,4 +29,4 @@ MICA_LOG=/var/log/mica2
 MICA_ARGS=""
 
 # arguments to pass to java
-JAVA_ARGS="-Xms2G -Xmx2G -XX:MaxPermSize=256M"
+JAVA_ARGS="-Xms2G -Xmx2G"

--- a/mica-dist/src/main/rpm/mica2.default
+++ b/mica-dist/src/main/rpm/mica2.default
@@ -29,4 +29,4 @@ MICA_LOG=/var/log/mica2
 MICA_ARGS=""
 
 # arguments to pass to java
-JAVA_ARGS="-Xms2G -Xmx2G -XX:MaxPermSize=256M"
+JAVA_ARGS="-Xms2G -Xmx2G


### PR DESCRIPTION
… it; for #4406

after reading https://dzone.com/articles/java-8-permgen-metaspace
it seems that java 8 (or at least Oracle's flavour) uses Metaspace now.

can config with `MaxMetaspaceSize` (e.g. `-XX:MaxMetaspaceSize=128m`)
it is unbounded by default.

