### PR TITLE
Use a string for wordLimit add-on

### DIFF
--- a/mica-core/src/main/resources/config/data-access-amendment-form/definition.json
+++ b/mica-core/src/main/resources/config/data-access-amendment-form/definition.json
@@ -283,7 +283,7 @@
         "key": "abstract",
         "notitle": true,
         "type": "textarea",
-        "wordLimit": 500,
+        "wordLimit": "0:500",
         "validationMessage": {
           "wordLimitError": "The 500 words limit has been exceeded."
         }
@@ -302,7 +302,7 @@
         "key": "summary",
         "notitle": true,
         "type": "textarea",
-        "wordLimit": 200,
+        "wordLimit": "0:200",
         "validationMessage": {
           "wordLimitError": "The 200 words limit has been exceeded."
         }
@@ -385,7 +385,7 @@
         "key": "other",
         "type": "textarea",
         "rows": 5,
-        "wordLimit": 500,
+        "wordLimit": "0:500",
         "validationMessage": {
           "wordLimitError": "The 500 words limit has been exceeded."
         }

--- a/mica-core/src/main/resources/config/data-access-form/definition.json
+++ b/mica-core/src/main/resources/config/data-access-form/definition.json
@@ -198,7 +198,7 @@
         "key": "abstract",
         "notitle": true,
         "type": "textarea",
-        "wordLimit": 500,
+        "wordLimit": "0:500",
         "validationMessage": {
           "wordLimitError": "The 500 words limit has been exceeded."
         }
@@ -216,7 +216,7 @@
         "key": "summary",
         "notitle": true,
         "type": "textarea",
-        "wordLimit": 200,
+        "wordLimit": "0:200",
         "validationMessage": {
           "wordLimitError": "The 200 words limit has been exceeded."
         }

--- a/mica-core/src/main/resources/config/data-access-preliminary-form/definition.json
+++ b/mica-core/src/main/resources/config/data-access-preliminary-form/definition.json
@@ -124,7 +124,7 @@
         "key": "abstract",
         "notitle": true,
         "type": "textarea",
-        "wordLimit": 500,
+        "wordLimit": "0:500",
         "validationMessage": {
           "wordLimitError": "The 500 words limit has been exceeded."
         }


### PR DESCRIPTION
There was a fix in ng-obiba-mica (c532bc4767e6d323da8c8fc1e0d4ff79ad2371da) to make word limits a range and consequently the type is not a string. Chose the range ("0:500") as default to hint the value can be a range, otherwise "500" also works.