### PR TITLE
Added a special css class for input

### DIFF
--- a/mica-webapp/src/main/webapp/assets/css/bootstrap-3-4.css
+++ b/mica-webapp/src/main/webapp/assets/css/bootstrap-3-4.css
@@ -50,6 +50,10 @@
   display: table;
 }
 
+.bootstrap3 .input-group input[bs-datepicker] {
+  min-width: 100%;
+}
+
 .input-group-btn {
   display: none;
 }


### PR DESCRIPTION
Most probably due to css incompatibility the <input> , after editing, the Input had `width=1%` and `min-width=0`!!

The fix specifically target `bs-datepicker`. tested with default schema and CanPath's.