### PR TITLE
fix: updated spring boot, shiro etc. and let protobuf provider write protobuf DTOs to JSON

### DIFF
--- a/mica-core/pom.xml
+++ b/mica-core/pom.xml
@@ -113,8 +113,8 @@
       <artifactId>metrics-spring</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/mica-rest/pom.xml
+++ b/mica-rest/pom.xml
@@ -75,6 +75,10 @@
       <artifactId>jersey-media-multipart</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/mica-rest/src/main/java/org/obiba/mica/config/JerseyConfiguration.java
+++ b/mica-rest/src/main/java/org/obiba/mica/config/JerseyConfiguration.java
@@ -13,6 +13,9 @@ package org.obiba.mica.config;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.ApplicationPath;
 
+import org.glassfish.jersey.internal.InternalProperties;
+import org.glassfish.jersey.jackson.internal.jackson.jaxrs.base.JsonMappingExceptionMapper;
+import org.glassfish.jersey.jackson.internal.jackson.jaxrs.base.JsonParseExceptionMapper;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.ServerProperties;
@@ -34,8 +37,17 @@ public class JerseyConfiguration extends ResourceConfig {
   @Inject
   public JerseyConfiguration(Environment environment, CSRFTokenHelper csrfTokenHelper) {
     register(RequestContextFilter.class);
-    packages("org.obiba.mica", "org.obiba.jersey", "com.fasterxml.jackson");
-    // register(LoggingFeature.class);
+    packages("org.obiba.mica", "org.obiba.jersey");
+    // Opt out of JacksonFeature's auto-registered DefaultJacksonJaxbJsonProvider and use MicaJacksonJsonProvider
+    // instead: it does the same job but declines protobuf messages, which are the ProtobufJsonProvider's business.
+    // Both providers declare MessageBodyWriter<Object> for application/json, so Jersey cannot order them by type or
+    // media type distance and picks whichever comes first in an unordered set. When Jackson wins, writing a protobuf
+    // DTO fails with "Direct self-reference leading to cycle" (UnknownFieldSet) and the response turns into an error.
+    property(InternalProperties.JSON_FEATURE, MicaJacksonJsonProvider.class.getSimpleName());
+    register(MicaJacksonJsonProvider.class);
+    // exception mappers JacksonFeature would have registered along with its provider
+    register(JsonParseExceptionMapper.class);
+    register(JsonMappingExceptionMapper.class);
     register(AuthenticationInterceptor.class);
     register(ConfigurationInterceptor.class);
     register(AuditInterceptor.class);

--- a/mica-rest/src/main/java/org/obiba/mica/config/MicaJacksonJsonProvider.java
+++ b/mica-rest/src/main/java/org/obiba/mica/config/MicaJacksonJsonProvider.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.obiba.mica.config;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Configuration;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.ext.Providers;
+
+import com.google.protobuf.Message;
+import org.glassfish.jersey.jackson.internal.DefaultJacksonJaxbJsonProvider;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+
+/**
+ * Jackson JSON provider that leaves protobuf messages to {@link org.obiba.jersey.protobuf.ProtobufJsonProvider}.
+ * <p>
+ * Both providers declare {@code MessageBodyWriter<Object>} for {@code application/json}, so Jersey cannot tell them
+ * apart by type or media type distance and picks whichever comes first in an unordered provider set. When Jackson wins,
+ * writing a protobuf DTO fails with "Direct self-reference leading to cycle" on {@code UnknownFieldSet}. Declining
+ * protobuf types here makes the choice deterministic, whatever the provider order happens to be.
+ *
+ * @see JerseyConfiguration
+ */
+@Provider
+@Singleton
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+public class MicaJacksonJsonProvider extends DefaultJacksonJaxbJsonProvider {
+
+  @Inject
+  public MicaJacksonJsonProvider(@Context Providers providers, @Context Configuration config) {
+    super(providers, config);
+  }
+
+  @Override
+  public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    return !isProtobuf(type, genericType) && super.isReadable(type, genericType, annotations, mediaType);
+  }
+
+  @Override
+  public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    return !isProtobuf(type, genericType) && super.isWriteable(type, genericType, annotations, mediaType);
+  }
+
+  /**
+   * A protobuf message, or a collection/array of protobuf messages, as accepted by ProtobufJsonProvider.
+   */
+  private static boolean isProtobuf(Class<?> type, Type genericType) {
+    if (Message.class.isAssignableFrom(type)) return true;
+    if (type.isArray()) return Message.class.isAssignableFrom(type.getComponentType());
+    if (!Iterable.class.isAssignableFrom(type)) return false;
+    if (genericType instanceof ParameterizedType) {
+      Type[] arguments = ((ParameterizedType) genericType).getActualTypeArguments();
+      return arguments.length == 1 && arguments[0] instanceof Class
+        && Message.class.isAssignableFrom((Class<?>) arguments[0]);
+    }
+    return false;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>4.0.6</version>
+    <version>4.1.0</version>
   </parent>
 
   <modules>
@@ -40,46 +40,46 @@
     <maven.compiler.source>21</maven.compiler.source>
 
     <assertj-core.version>3.27.7</assertj-core.version>
-    <awaitility.version>4.2.1</awaitility.version>
+    <awaitility.version>4.3.0</awaitility.version>
+    <bouncycastle.version>1.85</bouncycastle.version>
     <cache-api.version>1.1.1</cache-api.version>
     <carrotsearch.version>0.7.1</carrotsearch.version>
-    <commons-io.version>2.16.1</commons-io.version>
-    <commons-lang.version>2.6</commons-lang.version>
-    <dropwizard-metrics.version>4.2.23</dropwizard-metrics.version>
+    <commons-io.version>2.22.0</commons-io.version>
+    <commons-lang.version>3.18.0</commons-lang.version>
+    <dropwizard-metrics.version>4.2.39</dropwizard-metrics.version>
     <ehcache.version>3.10.8</ehcache.version>
-    <easymock.version>5.2.0</easymock.version>
+    <easymock.version>5.6.0</easymock.version>
     <embed-mongo.version>1.50.0</embed-mongo.version>
     <esapi.version>2.6.0.0</esapi.version>
-    <freemarker.version>2.3.33</freemarker.version>
-    <guava.version>33.2.1-jre</guava.version>
+    <freemarker.version>2.3.34</freemarker.version>
+    <guava.version>33.6.0-jre</guava.version>
 <!--    <geronimo-javamail_1.4_mail.version>1.8.3</geronimo-javamail_1.4_mail.version>-->
     <itextpdf.version>5.5.13.4</itextpdf.version>
     <javax.inject.version>1</javax.inject.version>
     <javax-rs.version>2.0</javax-rs.version>
-    <jersey.version>3.1.3</jersey.version>
-    <jetty.version>12.1.6</jetty.version>
-    <jgit.version>7.2.1.202505142326-r</jgit.version>
-    <jhipsterloaded.version>0.7</jhipsterloaded.version>
-    <joda-time.version>2.12.7</joda-time.version>
-    <json-path.version>2.9.0</json-path.version>
+    <jersey.version>3.1.12</jersey.version>
+    <jetty.version>12.1.11</jetty.version>
+    <jgit.version>7.7.0.202606012155-r</jgit.version>
+    <jhipsterloaded.version>0.12</jhipsterloaded.version>
+    <joda-time.version>2.14.2</joda-time.version>
+    <json-path.version>2.10.0</json-path.version>
     <jsoup.version>1.17.2</jsoup.version>
-    <jsr305.version>3.0.0</jsr305.version>
-    <logback.version>1.5.35</logback.version>
+    <jsr305.version>3.0.2</jsr305.version>
+    <logback.version>1.6.0</logback.version>
     <logstash-logback.version>7.4</logstash-logback.version>
     <magma.version>5.3.0</magma.version>
     <metrics-spring.version>3.0.0</metrics-spring.version>
-    <mongodb-driver.version>5.6.3</mongodb-driver.version>
+    <mongodb-driver.version>5.9.1</mongodb-driver.version>
     <nosqlunit.version>0.7.9</nosqlunit.version>
-    <obiba-commons.version>5.1.2</obiba-commons.version>
-    <opal.version>5.6.3</opal.version>
-    <bouncycastle.version>1.84</bouncycastle.version>
+    <obiba-commons.version>5.2.1</obiba-commons.version>
+    <opal.version>5.7.3</opal.version>
     <opencsv.version>2.3</opencsv.version>
     <poi.version>5.4.0</poi.version>
-    <protobuf.version>3.25.5</protobuf.version>
+    <protobuf.version>3.25.8</protobuf.version>
     <protobuf-java-format.version>1.2.1-obiba</protobuf-java-format.version>
     <rql-parser.version>0.3.3-obiba</rql-parser.version>
-    <shiro.version>2.1.0</shiro.version>
-    <shiro-extras.version>1.1.0</shiro-extras.version>
+    <shiro.version>2.2.1</shiro.version>
+    <shiro-extras.version>2.0.0</shiro-extras.version>
     <lang-tag.version>1.4.4</lang-tag.version>
     <servlet-api.version>6.1.0-M2</servlet-api.version>
     <jakarta.servlet>4.0.4</jakarta.servlet>
@@ -90,14 +90,14 @@
     <github-release-plugin.version>1.6.0</github-release-plugin.version>
     <maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
     <maven-assembly-plugin.version>2.4</maven-assembly-plugin.version>
-    <maven-dependency-plugin.version>3.1.0</maven-dependency-plugin.version>
-    <maven-deploy-plugin.version>2.8.1</maven-deploy-plugin.version>
-    <maven-enforcer-plugin.version>1.3.1</maven-enforcer-plugin.version>
+    <maven-dependency-plugin.version>3.11.0</maven-dependency-plugin.version>
+    <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+    <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
     <maven-findbugs-plugin.version>3.0.4</maven-findbugs-plugin.version>
-    <maven-pmd-plugin.version>3.1</maven-pmd-plugin.version>
+    <maven-pmd-plugin.version>3.6</maven-pmd-plugin.version>
     <maven-sonar-plugin.version>2.2</maven-sonar-plugin.version>
     <maven-release-plugin.version>2.5.2</maven-release-plugin.version>
-    <rpm-maven-plugin.version>2.1.4</rpm-maven-plugin.version>
+    <rpm-maven-plugin.version>2.2.0</rpm-maven-plugin.version>
 
   </properties>
 
@@ -204,8 +204,8 @@
         <version>${metrics-spring.version}</version>
       </dependency>
       <dependency>
-        <groupId>commons-lang</groupId>
-        <artifactId>commons-lang</artifactId>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
         <version>${commons-lang.version}</version>
       </dependency>
       <dependency>
@@ -345,6 +345,12 @@
       <dependency>
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>jersey-media-multipart</artifactId>
+        <version>${jersey.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.glassfish.jersey.media</groupId>
+        <artifactId>jersey-media-json-jackson</artifactId>
         <version>${jersey.version}</version>
       </dependency>
 


### PR DESCRIPTION
ProtobufJsonProvider and Jersey's auto-registered
DefaultJacksonJaxbJsonProvider both declare MessageBodyWriter<Object> for application/json, so Jersey's WorkerComparator ties on type distance, media type distance and the custom flag alike, and the winner is whichever comes first in an unordered provider set. When Jackson won, writing any protobuf DTO failed with "Direct self-reference leading to cycle" on UnknownFieldSet -- seen in the logs as a 401 from /auth/session/_current turning into a write failure.

Register MicaJacksonJsonProvider instead, a DefaultJacksonJaxbJsonProvider that declines protobuf messages and collections of them, so the choice no longer depends on provider order. JacksonFeature's own provider is opted out via InternalProperties.JSON_FEATURE; its two exception mappers are registered explicitly to keep the previous behaviour on malformed JSON.

Also bumps Spring Boot to 4.1.0 and the dependencies that follow from it, including commons-lang 2.6 -> commons-lang3 3.18.0.