### PR TITLE
Make reCAPTCHA optional in signup and contact forms (#4577)

### DIFF
--- a/mica-core/src/main/java/org/obiba/mica/core/service/UserAuthService.java
+++ b/mica-core/src/main/java/org/obiba/mica/core/service/UserAuthService.java
@@ -28,7 +28,13 @@ public class UserAuthService extends AgateRestService {
 
   private static final Logger log = LoggerFactory.getLogger(UserAuthService.class);
 
+  private static final String PUBLIC_CONFIGURATION_CACHE_KEY = "publicConfiguration";
+
   private static final String CLIENT_CONFIGURATION_CACHE_KEY = "clientConfiguration";
+
+  private final Cache<String, JSONObject> publicConfigurationCache = CacheBuilder.newBuilder()
+    .expireAfterWrite(5, TimeUnit.MINUTES)
+    .build();
 
   private final Cache<String, JSONObject> clientConfigurationCache = CacheBuilder.newBuilder()
     .expireAfterWrite(5, TimeUnit.MINUTES)
@@ -64,7 +70,16 @@ public class UserAuthService extends AgateRestService {
   }
 
   public synchronized JSONObject getPublicConfiguration() {
-    JSONObject config = getJSONObject(getPublicConfigurationUrl());
+    JSONObject config;
+    try {
+      config = publicConfigurationCache.get(PUBLIC_CONFIGURATION_CACHE_KEY, () -> getJSONObject(getPublicConfigurationUrl()));
+    } catch (ExecutionException e) {
+      log.warn("Cannot get Agate public configuration: {}", e.getMessage());
+      if (log.isDebugEnabled())
+        log.debug("Cannot get Agate public configuration", e);
+      return new JSONObject();
+    }
+    boolean fetchFailed = config.isEmpty();
     if (!config.has("publicUrl")) { // publicUrl as configured in Agate
       try {
         // publicUrl as configured in Mica
@@ -72,6 +87,11 @@ public class UserAuthService extends AgateRestService {
       } catch (JSONException e) {
         // ignore
       }
+    }
+    if (fetchFailed) {
+      // do not cache a failed/empty fetch, so that the next call retries against Agate instead of
+      // waiting out the full cache TTL
+      publicConfigurationCache.invalidate(PUBLIC_CONFIGURATION_CACHE_KEY);
     }
     return config;
   }

--- a/mica-core/src/main/java/org/obiba/mica/core/service/UserAuthService.java
+++ b/mica-core/src/main/java/org/obiba/mica/core/service/UserAuthService.java
@@ -77,11 +77,21 @@ public class UserAuthService extends AgateRestService {
   }
 
   public synchronized JSONObject getClientConfiguration() {
+    JSONObject config;
     try {
-      return clientConfigurationCache.get(CLIENT_CONFIGURATION_CACHE_KEY, () -> getJSONObject(getClientConfigurationUrl()));
+      config = clientConfigurationCache.get(CLIENT_CONFIGURATION_CACHE_KEY, () -> getJSONObject(getClientConfigurationUrl()));
     } catch (ExecutionException e) {
+      log.warn("Cannot get Agate client configuration: {}", e.getMessage());
+      if (log.isDebugEnabled())
+        log.debug("Cannot get Agate client configuration", e);
       return new JSONObject();
     }
+    if (config.isEmpty()) {
+      // do not cache a failed/empty fetch, so that the next call retries against Agate instead of
+      // waiting out the full cache TTL (which would otherwise wrongly disable reCAPTCHA for 5 minutes)
+      clientConfigurationCache.invalidate(CLIENT_CONFIGURATION_CACHE_KEY);
+    }
+    return config;
   }
 
   /**

--- a/mica-core/src/main/java/org/obiba/mica/core/service/UserAuthService.java
+++ b/mica-core/src/main/java/org/obiba/mica/core/service/UserAuthService.java
@@ -1,5 +1,8 @@
 package org.obiba.mica.core.service;
 
+import com.google.common.base.Strings;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Lists;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -14,6 +17,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 /**
  * User authentication, as delegated to Agate.
@@ -22,6 +27,12 @@ import java.util.Map;
 public class UserAuthService extends AgateRestService {
 
   private static final Logger log = LoggerFactory.getLogger(UserAuthService.class);
+
+  private static final String CLIENT_CONFIGURATION_CACHE_KEY = "clientConfiguration";
+
+  private final Cache<String, JSONObject> clientConfigurationCache = CacheBuilder.newBuilder()
+    .expireAfterWrite(5, TimeUnit.MINUTES)
+    .build();
 
   public synchronized List<OIDCAuthProviderSummary> getOidcProviders(String locale) {
     return getOidcProviders(locale, false);
@@ -66,7 +77,22 @@ public class UserAuthService extends AgateRestService {
   }
 
   public synchronized JSONObject getClientConfiguration() {
-    return getJSONObject(getClientConfigurationUrl());
+    try {
+      return clientConfigurationCache.get(CLIENT_CONFIGURATION_CACHE_KEY, () -> getJSONObject(getClientConfigurationUrl()));
+    } catch (ExecutionException e) {
+      return new JSONObject();
+    }
+  }
+
+  /**
+   * Whether a reCAPTCHA site key is configured in Agate. When not configured, forms must not require a captcha input.
+   */
+  public synchronized boolean isReCaptchaEnabled() {
+    try {
+      return !Strings.isNullOrEmpty(getClientConfiguration().getString("reCaptchaKey"));
+    } catch (JSONException e) {
+      return false;
+    }
   }
 
   //

--- a/mica-rest/src/main/java/org/obiba/mica/web/rest/user/UsersProfileResource.java
+++ b/mica-rest/src/main/java/org/obiba/mica/web/rest/user/UsersProfileResource.java
@@ -24,6 +24,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.apache.shiro.authz.annotation.RequiresRoles;
+import org.obiba.mica.core.service.UserAuthService;
 import org.obiba.mica.security.Roles;
 import org.obiba.mica.user.UserProfileService;
 import org.obiba.mica.web.model.Dtos;
@@ -43,6 +44,9 @@ public class UsersProfileResource {
 
   @Inject
   private UserProfileService userProfileService;
+
+  @Inject
+  private UserAuthService userAuthService;
 
   @Inject
   private Dtos dtos;
@@ -88,7 +92,10 @@ public class UsersProfileResource {
   public Response contact(@FormParam("name") String name, @FormParam("email") String email,
                           @FormParam("subject") String subject, @FormParam("message") String message,
                           @FormParam("g-recaptcha-response") String reCaptcha) {
-    if (Strings.isNullOrEmpty(name) || Strings.isNullOrEmpty(email) || Strings.isNullOrEmpty(subject) || Strings.isNullOrEmpty(message) || Strings.isNullOrEmpty(reCaptcha)) {
+    if (Strings.isNullOrEmpty(name) || Strings.isNullOrEmpty(email) || Strings.isNullOrEmpty(subject) || Strings.isNullOrEmpty(message)) {
+      throw new BadRequestException();
+    }
+    if (userAuthService.isReCaptchaEnabled() && Strings.isNullOrEmpty(reCaptcha)) {
       throw new BadRequestException();
     }
     userProfileService.sendContactEmail(ESAPI.encoder().encodeForHTML(name), ESAPI.encoder().encodeForHTML(email),

--- a/mica-webapp/src/main/resources/_templates/contact.ftl
+++ b/mica-webapp/src/main/resources/_templates/contact.ftl
@@ -3,6 +3,7 @@
 <head>
   <#include "libs/head.ftl">
   <title>${config.name!""} | <@message "contact-title"/></title>
+  <#if reCaptchaKey?has_content>
   <script type="text/javascript">
     var onloadCallback = function() {
       grecaptcha.render('html_element', {
@@ -10,6 +11,7 @@
       });
     };
   </script>
+  </#if>
 </head>
 <body class="hold-transition layout-top-nav layout-navbar-fixed">
 <div class="app-wrapper d-flex flex-column min-vh-100">
@@ -68,8 +70,10 @@
                 <label for="contact-message"><@message "contact-message"/></label>
                 <textarea class="form-control" id="contact-message" name="message" rows="6"></textarea>
               </div>
-              <div id="html_element" class="mb-3"></div>
-              <button type="submit" class="btn btn-primary"><@message "contact-send"/></button>
+              <#if reCaptchaKey?has_content>
+              <div id="html_element" class="mt-3"></div>
+              </#if>
+              <button type="submit" class="btn btn-primary mt-3"><@message "contact-send"/></button>
             </form>
           </div>
         </div>
@@ -84,9 +88,11 @@
 <!-- ./wrapper -->
 
 <#include "libs/scripts.ftl">
+<#if reCaptchaKey?has_content>
 <script src="https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit&hl=${.lang}"
         async defer>
 </script>
+</#if>
 <#include "libs/contact-scripts.ftl">
 
 </body>

--- a/mica-webapp/src/main/resources/_templates/libs/contact-scripts.ftl
+++ b/mica-webapp/src/main/resources/_templates/libs/contact-scripts.ftl
@@ -8,8 +8,10 @@
       { name: "name", title: "<@message "contact-name"/>" },
       { name: "email", title: "<@message "contact-email"/>" },
       { name: "subject", title: "<@message "contact-subject"/>" },
-      { name: "message", title: "<@message "contact-message"/>" },
-      { name: "g-recaptcha-response", title: "<@message "captcha"/>" }
+      { name: "message", title: "<@message "contact-message"/>" }
+      <#if reCaptchaKey?has_content>
+      , { name: "g-recaptcha-response", title: "<@message "captcha"/>" }
+      </#if>
     ];
     UserService.contact("#form", requiredFields, function() {
       let form = document.querySelector("#form");

--- a/mica-webapp/src/main/resources/_templates/signup-with.ftl
+++ b/mica-webapp/src/main/resources/_templates/signup-with.ftl
@@ -132,19 +132,19 @@
   UserService.refreshSignupWith()
   </#if>
   const requiredFields = [
-    { name: "email", title: "<@message "email"/>" },
-    { name: "firstname", title: "<@message "firstname"/>" },
-    { name: "lastname", title: "<@message "lastname"/>" },
+    { name: "email", title: "<@message "email"/>" }
+    , { name: "firstname", title: "<@message "firstname"/>" }
+    , { name: "lastname", title: "<@message "lastname"/>" }
     <#if authConfig.joinWithUsername>
-      { name: "username", title: "<@message "username"/>" },
+      , { name: "username", title: "<@message "username"/>" }
     </#if>
     <#list authConfig.userAttributes as attribute>
       <#if attribute.required>
-        { name: "${attribute.name}", title: "<@message attribute.name/>" },
+        , { name: "${attribute.name}", title: "<@message attribute.name/>" }
       </#if>
     </#list>
     <#if authConfig.reCaptchaKey?has_content>
-    { name: "g-recaptcha-response", title: "<@message "captcha"/>" }
+    , { name: "g-recaptcha-response", title: "<@message "captcha"/>" }
     </#if>
   ];
 </script>

--- a/mica-webapp/src/main/resources/_templates/signup-with.ftl
+++ b/mica-webapp/src/main/resources/_templates/signup-with.ftl
@@ -7,6 +7,7 @@
   <title>${config.name?default("")} | <@message "sign-up"/></title>
   <!-- Tell the browser to be responsive to screen width -->
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <#if authConfig.reCaptchaKey?has_content>
   <script type="text/javascript">
     var onloadCallback = function() {
       grecaptcha.render('html_element', {
@@ -14,6 +15,7 @@
       });
     };
   </script>
+  </#if>
 </head>
 <body id="signup-with-page" class="hold-transition login-page">
 <div class="login-box">
@@ -95,7 +97,9 @@
           </div>
         </#list>
 
+        <#if authConfig.reCaptchaKey?has_content>
         <div id="html_element" class="mb-3"></div>
+        </#if>
         <div class="row">
           <div class="col-6">
           </div>
@@ -107,9 +111,11 @@
         </div>
       </form>
 
+      <#if authConfig.reCaptchaKey?has_content>
       <script src="https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit"
               async defer>
       </script>
+      </#if>
 
       <p class="mb-1">
         <a href="signin" class="text-center"><@message "already-have-a-membership"/></a>
@@ -137,7 +143,9 @@
         { name: "${attribute.name}", title: "<@message attribute.name/>" },
       </#if>
     </#list>
+    <#if authConfig.reCaptchaKey?has_content>
     { name: "g-recaptcha-response", title: "<@message "captcha"/>" }
+    </#if>
   ];
 </script>
 <#include "libs/signup-scripts.ftl">

--- a/mica-webapp/src/main/resources/_templates/signup.ftl
+++ b/mica-webapp/src/main/resources/_templates/signup.ftl
@@ -7,6 +7,7 @@
   <title>${config.name!""} | <@message "sign-up"/></title>
   <!-- Tell the browser to be responsive to screen width -->
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <#if authConfig.reCaptchaKey?has_content>
   <script type="text/javascript">
     var onloadCallback = function() {
       grecaptcha.render('html_element', {
@@ -14,6 +15,7 @@
       });
     };
   </script>
+  </#if>
 </head>
 <body id="signup-page" class="hold-transition login-page">
 <div class="login-box">
@@ -105,7 +107,9 @@
           </div>
         </#list>
 
+        <#if authConfig.reCaptchaKey?has_content>
         <div id="html_element" class="mb-3"></div>
+        </#if>
         <div class="d-flex justify-content-end">
           <button type="submit" class="btn btn-primary w-50">
             <i class="spinner-border spinner-border-sm" style="display: none;"></i> <@message "sign-up-submit"/>
@@ -113,9 +117,11 @@
         </div>
       </form>
 
+      <#if authConfig.reCaptchaKey?has_content>
       <script src="https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit"
               async defer>
       </script>
+      </#if>
 
       <#if oidcProviders?? && oidcProviders?size != 0>
         <div class="social-auth-links text-center mb-3">
@@ -155,7 +161,9 @@
         { name: "${attribute.name}", title: "<@message attribute.name/>" },
       </#if>
     </#list>
+    <#if authConfig.reCaptchaKey?has_content>
     { name: "g-recaptcha-response", title: "<@message "captcha"/>" }
+    </#if>
   ];
 </script>
 <#include "libs/signup-scripts.ftl">

--- a/mica-webapp/src/main/resources/_templates/signup.ftl
+++ b/mica-webapp/src/main/resources/_templates/signup.ftl
@@ -147,22 +147,22 @@
 <#include "libs/scripts.ftl">
 <script>
   const requiredFields = [
-    { name: "email", title: "<@message "email"/>" },
+    { name: "email", title: "<@message "email"/>" }
     <#if config.signupWithPassword>
-      { name: "password", title: "<@message "password"/>" },
+      , { name: "password", title: "<@message "password"/>" }
     </#if>
-    { name: "firstname", title: "<@message "firstname"/>" },
-    { name: "lastname", title: "<@message "lastname"/>" },
+    , { name: "firstname", title: "<@message "firstname"/>" }
+    , { name: "lastname", title: "<@message "lastname"/>" }
     <#if authConfig.joinWithUsername>
-      { name: "username", title: "<@message "username"/>" },
+      , { name: "username", title: "<@message "username"/>" }
     </#if>
     <#list authConfig.userAttributes as attribute>
       <#if attribute.required>
-        { name: "${attribute.name}", title: "<@message attribute.name/>" },
+        , { name: "${attribute.name}", title: "<@message attribute.name/>" }
       </#if>
     </#list>
     <#if authConfig.reCaptchaKey?has_content>
-    { name: "g-recaptcha-response", title: "<@message "captcha"/>" }
+    , { name: "g-recaptcha-response", title: "<@message "captcha"/>" }
     </#if>
   ];
 </script>


### PR DESCRIPTION
* reCAPTCHA is an optional setting in Agate. When no site key is configured there, the signup and contact forms no longer render the widget or require a captcha response, both client-side and in the contact REST endpoint. 
* The Agate public and client configurations are now cached for 5 minutes in UserAuthService to avoid repeated calls when checking this on every form render.