### PR TITLE
Fix contact form email not sent when reCAPTCHA is disabled (#4580)

### DIFF
--- a/mica-core/src/main/java/org/obiba/mica/core/service/MailService.java
+++ b/mica-core/src/main/java/org/obiba/mica/core/service/MailService.java
@@ -130,7 +130,7 @@ public class MailService extends AgateRestService {
         .append(encode(templateName, "UTF-8"));
       context.forEach((k, v) -> {
         try {
-          form.append("&").append(k).append("=").append(encode(v, "UTF-8"));
+          form.append("&").append(k).append("=").append(encode(Strings.nullToEmpty(v), "UTF-8"));
         } catch(UnsupportedEncodingException ignored) {
         }
       });

--- a/mica-core/src/main/java/org/obiba/mica/user/UserProfileService.java
+++ b/mica-core/src/main/java/org/obiba/mica/user/UserProfileService.java
@@ -235,7 +235,9 @@ public class UserProfileService extends AgateRestService {
     ctx.put("contactEmail", email);
     ctx.put("contactSubject", subject);
     ctx.put("contactMessage", message);
-    ctx.put("reCaptcha", reCaptcha);
+    // reCAPTCHA is optional in Agate: only forward a response when there is one, otherwise Agate
+    // would try to verify a missing captcha
+    if (!Strings.isNullOrEmpty(reCaptcha)) ctx.put("reCaptcha", reCaptcha);
 
     List<String> contactGroups = config.getContactGroups();
     String[] groups = new String[contactGroups.size()];


### PR DESCRIPTION
When no reCAPTCHA site key is configured in Agate, the contact form submits no g-recaptcha-response, so a null value ended up in the email template context. MailService URL-encodes every context value, and encode(null, "UTF-8") throws a NullPointerException that was swallowed by the outer catch and mislogged as an Agate connection failure. The send is @Async, so the form still reported success while no email was ever sent.

Only forward reCaptcha to Agate when there is a response, and encode null context values as empty strings so a single null cannot break a whole notification.
